### PR TITLE
chore(kafka-backup-operator): sync chart v0.1.1

### DIFF
--- a/charts/kafka-backup-operator/Chart.yaml
+++ b/charts/kafka-backup-operator/Chart.yaml
@@ -1,0 +1,22 @@
+apiVersion: v2
+name: kafka-backup-operator
+description: A Kubernetes operator for managing Kafka backup and restore operations
+type: application
+version: 0.1.1
+appVersion: "0.1.0"
+home: https://github.com/osodevops/kafka-backup-operator
+sources:
+  - https://github.com/osodevops/kafka-backup-operator
+maintainers:
+  - name: sionsmith
+    email: dev@oso.sh
+    url: https://github.com/sionsmith
+keywords:
+  - kafka
+  - backup
+  - restore
+  - operator
+  - disaster-recovery
+icon: https://raw.githubusercontent.com/osodevops/kafka-backup-operator/main/docs/icon.png
+annotations:
+  category: Infrastructure

--- a/charts/kafka-backup-operator/crds/all.yaml
+++ b/charts/kafka-backup-operator/crds/all.yaml
@@ -1,0 +1,1550 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkabackups.kafka.oso.sh
+spec:
+  group: kafka.oso.sh
+  names:
+    categories: []
+    kind: KafkaBackup
+    plural: kafkabackups
+    shortNames:
+    - kb
+    singular: kafkabackup
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.lastBackupTime
+      name: Last Backup
+      type: string
+    - jsonPath: .status.recordsProcessed
+      name: Records
+      type: integer
+    - jsonPath: .status.resumable
+      name: Resumable
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for KafkaBackupSpec via `CustomResource`
+        properties:
+          spec:
+            description: KafkaBackup resource specification
+            properties:
+              checkpoint:
+                description: Checkpoint configuration for resumable backups
+                nullable: true
+                properties:
+                  enabled:
+                    default: true
+                    description: Enable checkpointing
+                    type: boolean
+                  intervalSecs:
+                    default: 30
+                    description: Checkpoint interval in seconds
+                    format: uint64
+                    minimum: 0.0
+                    type: integer
+                  storage:
+                    description: Separate checkpoint storage (defaults to backup storage)
+                    nullable: true
+                    properties:
+                      pvcName:
+                        description: PVC name for checkpoints
+                        type: string
+                      subPath:
+                        description: Sub-path within PVC
+                        nullable: true
+                        type: string
+                    required:
+                    - pvcName
+                    type: object
+                type: object
+              circuitBreaker:
+                description: Circuit breaker configuration
+                nullable: true
+                properties:
+                  enabled:
+                    default: true
+                    description: Enable circuit breaker
+                    type: boolean
+                  failureThreshold:
+                    default: 5
+                    description: Failure threshold before opening circuit
+                    format: uint32
+                    minimum: 0.0
+                    type: integer
+                  operationTimeoutMs:
+                    default: 30000
+                    description: Operation timeout (milliseconds)
+                    format: uint64
+                    minimum: 0.0
+                    type: integer
+                  resetTimeoutSecs:
+                    default: 60
+                    description: Time to wait before attempting recovery (seconds)
+                    format: uint64
+                    minimum: 0.0
+                    type: integer
+                  successThreshold:
+                    default: 3
+                    description: Success threshold to close circuit
+                    format: uint32
+                    minimum: 0.0
+                    type: integer
+                type: object
+              compression:
+                default: zstd
+                description: Compression algorithm (none, lz4, zstd)
+                type: string
+              compressionLevel:
+                default: 3
+                description: Compression level (1-22 for zstd)
+                format: int32
+                type: integer
+              kafkaCluster:
+                description: Kafka cluster connection configuration
+                properties:
+                  bootstrapServers:
+                    description: Bootstrap servers
+                    items:
+                      type: string
+                    type: array
+                  saslSecret:
+                    description: SASL configuration secret reference
+                    nullable: true
+                    properties:
+                      mechanism:
+                        description: SASL mechanism (PLAIN, SCRAM-SHA-256, SCRAM-SHA-512)
+                        type: string
+                      name:
+                        description: Secret name
+                        type: string
+                      passwordKey:
+                        default: password
+                        description: Password key in secret
+                        type: string
+                      usernameKey:
+                        default: username
+                        description: Username key in secret
+                        type: string
+                    required:
+                    - mechanism
+                    - name
+                    type: object
+                  securityProtocol:
+                    default: PLAINTEXT
+                    description: Security protocol (PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL)
+                    type: string
+                  tlsSecret:
+                    description: TLS configuration secret reference
+                    nullable: true
+                    properties:
+                      caKey:
+                        default: ca.crt
+                        description: CA certificate key in secret
+                        type: string
+                      certKey:
+                        description: Client certificate key in secret
+                        nullable: true
+                        type: string
+                      keyKey:
+                        description: Client key key in secret
+                        nullable: true
+                        type: string
+                      name:
+                        description: Secret name
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - bootstrapServers
+                type: object
+              rateLimiting:
+                description: Rate limiting configuration
+                nullable: true
+                properties:
+                  bytesPerSec:
+                    default: 0
+                    description: Maximum bytes per second (0 = unlimited)
+                    format: uint64
+                    minimum: 0.0
+                    type: integer
+                  maxConcurrentPartitions:
+                    default: 4
+                    description: Maximum concurrent partitions
+                    format: uint
+                    minimum: 0.0
+                    type: integer
+                  recordsPerSec:
+                    default: 0
+                    description: Maximum records per second (0 = unlimited)
+                    format: uint64
+                    minimum: 0.0
+                    type: integer
+                type: object
+              schedule:
+                description: Cron schedule for automated backups
+                nullable: true
+                type: string
+              storage:
+                description: Storage configuration
+                properties:
+                  azure:
+                    description: Azure Blob storage configuration
+                    nullable: true
+                    properties:
+                      accountName:
+                        description: Storage account name
+                        type: string
+                      container:
+                        description: Container name
+                        type: string
+                      credentialsSecret:
+                        description: Credentials secret reference
+                        properties:
+                          accountKeyKey:
+                            default: AZURE_STORAGE_KEY
+                            description: Account key key in secret
+                            type: string
+                          name:
+                            description: Secret name
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      prefix:
+                        description: Path prefix within container
+                        nullable: true
+                        type: string
+                    required:
+                    - accountName
+                    - container
+                    - credentialsSecret
+                    type: object
+                  gcs:
+                    description: GCS storage configuration
+                    nullable: true
+                    properties:
+                      bucket:
+                        description: GCS bucket name
+                        type: string
+                      credentialsSecret:
+                        description: Credentials secret reference
+                        properties:
+                          name:
+                            description: Secret name
+                            type: string
+                          serviceAccountJsonKey:
+                            default: SERVICE_ACCOUNT_JSON
+                            description: Service account JSON key in secret
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      prefix:
+                        description: Path prefix within bucket
+                        nullable: true
+                        type: string
+                    required:
+                    - bucket
+                    - credentialsSecret
+                    type: object
+                  pvc:
+                    description: PVC storage configuration
+                    nullable: true
+                    properties:
+                      claimName:
+                        description: PVC claim name
+                        type: string
+                      create:
+                        description: Auto-create PVC if not exists
+                        nullable: true
+                        properties:
+                          accessModes:
+                            default:
+                            - ReadWriteOnce
+                            description: Access modes
+                            items:
+                              type: string
+                            type: array
+                          enabled:
+                            default: false
+                            description: Enable auto-creation
+                            type: boolean
+                          size:
+                            default: 100Gi
+                            description: Storage size (e.g., "100Gi")
+                            type: string
+                          storageClassName:
+                            description: Storage class name
+                            nullable: true
+                            type: string
+                        type: object
+                      subPath:
+                        description: Sub-path within the PVC
+                        nullable: true
+                        type: string
+                    required:
+                    - claimName
+                    type: object
+                  s3:
+                    description: S3 storage configuration
+                    nullable: true
+                    properties:
+                      bucket:
+                        description: S3 bucket name
+                        type: string
+                      credentialsSecret:
+                        description: Credentials secret reference
+                        properties:
+                          accessKeyIdKey:
+                            default: AWS_ACCESS_KEY_ID
+                            description: Access key ID key in secret
+                            type: string
+                          name:
+                            description: Secret name
+                            type: string
+                          secretAccessKeyKey:
+                            default: AWS_SECRET_ACCESS_KEY
+                            description: Secret access key key in secret
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      endpoint:
+                        description: Custom endpoint (for MinIO, Ceph, etc.)
+                        nullable: true
+                        type: string
+                      prefix:
+                        description: Path prefix within bucket
+                        nullable: true
+                        type: string
+                      region:
+                        description: AWS region
+                        type: string
+                    required:
+                    - bucket
+                    - credentialsSecret
+                    - region
+                    type: object
+                  storageType:
+                    default: pvc
+                    description: Storage type (pvc, s3, azure, gcs)
+                    type: string
+                type: object
+              suspend:
+                default: false
+                description: Suspend backups (useful for maintenance)
+                type: boolean
+              topics:
+                description: Topics to backup
+                items:
+                  type: string
+                type: array
+            required:
+            - kafkaCluster
+            - storage
+            - topics
+            type: object
+          status:
+            description: KafkaBackup status
+            nullable: true
+            properties:
+              backupId:
+                description: Current backup ID
+                nullable: true
+                type: string
+              bytesProcessed:
+                description: Bytes processed in current/last backup
+                format: uint64
+                minimum: 0.0
+                nullable: true
+                type: integer
+              checkpointEnabled:
+                description: Whether checkpointing is enabled
+                nullable: true
+                type: boolean
+              conditions:
+                description: Status conditions
+                items:
+                  description: Status condition
+                  properties:
+                    lastTransitionTime:
+                      description: Last transition time
+                      format: date-time
+                      type: string
+                    message:
+                      description: Human-readable message
+                      nullable: true
+                      type: string
+                    reason:
+                      description: Reason for the condition
+                      nullable: true
+                      type: string
+                    status:
+                      description: Status (True, False, Unknown)
+                      type: string
+                    type:
+                      description: Condition type
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastBackupTime:
+                description: Last backup timestamp
+                format: date-time
+                nullable: true
+                type: string
+              lastCheckpointTime:
+                description: Last checkpoint timestamp
+                format: date-time
+                nullable: true
+                type: string
+              message:
+                description: Human-readable message
+                nullable: true
+                type: string
+              nextScheduledBackup:
+                description: Next scheduled backup timestamp
+                format: date-time
+                nullable: true
+                type: string
+              observedGeneration:
+                description: Observed generation
+                format: int64
+                nullable: true
+                type: integer
+              phase:
+                description: Current phase (Pending, Running, Completed, Failed)
+                nullable: true
+                type: string
+              recordsProcessed:
+                description: Records processed in current/last backup
+                format: uint64
+                minimum: 0.0
+                nullable: true
+                type: integer
+              resumable:
+                description: Whether the backup can be resumed
+                nullable: true
+                type: boolean
+              segmentsCompleted:
+                description: Segments completed in current/last backup
+                format: uint64
+                minimum: 0.0
+                nullable: true
+                type: integer
+              throughputBytesPerSec:
+                description: Throughput (bytes per second)
+                format: double
+                nullable: true
+                type: number
+              throughputRecordsPerSec:
+                description: Throughput (records per second)
+                format: double
+                nullable: true
+                type: number
+            type: object
+        required:
+        - spec
+        title: KafkaBackup
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkarestores.kafka.oso.sh
+spec:
+  group: kafka.oso.sh
+  names:
+    categories: []
+    kind: KafkaRestore
+    plural: kafkarestores
+    shortNames:
+    - kr
+    singular: kafkarestore
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.progressPercent
+      name: Progress
+      type: string
+    - jsonPath: .status.recordsRestored
+      name: Records
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for KafkaRestoreSpec via `CustomResource`
+        properties:
+          spec:
+            description: KafkaRestore resource specification
+            properties:
+              backupRef:
+                description: Reference to backup to restore from
+                properties:
+                  backupId:
+                    description: Specific backup ID (if multiple backups exist)
+                    nullable: true
+                    type: string
+                  name:
+                    description: KafkaBackup resource name
+                    type: string
+                  namespace:
+                    description: Namespace (defaults to same namespace)
+                    nullable: true
+                    type: string
+                  storage:
+                    description: 'Alternative: Direct storage reference (for external backups)'
+                    nullable: true
+                    properties:
+                      azure:
+                        description: Azure Blob storage configuration
+                        nullable: true
+                        properties:
+                          accountName:
+                            description: Storage account name
+                            type: string
+                          container:
+                            description: Container name
+                            type: string
+                          credentialsSecret:
+                            description: Credentials secret reference
+                            properties:
+                              accountKeyKey:
+                                default: AZURE_STORAGE_KEY
+                                description: Account key key in secret
+                                type: string
+                              name:
+                                description: Secret name
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          prefix:
+                            description: Path prefix within container
+                            nullable: true
+                            type: string
+                        required:
+                        - accountName
+                        - container
+                        - credentialsSecret
+                        type: object
+                      gcs:
+                        description: GCS storage configuration
+                        nullable: true
+                        properties:
+                          bucket:
+                            description: GCS bucket name
+                            type: string
+                          credentialsSecret:
+                            description: Credentials secret reference
+                            properties:
+                              name:
+                                description: Secret name
+                                type: string
+                              serviceAccountJsonKey:
+                                default: SERVICE_ACCOUNT_JSON
+                                description: Service account JSON key in secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          prefix:
+                            description: Path prefix within bucket
+                            nullable: true
+                            type: string
+                        required:
+                        - bucket
+                        - credentialsSecret
+                        type: object
+                      pvc:
+                        description: PVC storage configuration
+                        nullable: true
+                        properties:
+                          claimName:
+                            description: PVC claim name
+                            type: string
+                          create:
+                            description: Auto-create PVC if not exists
+                            nullable: true
+                            properties:
+                              accessModes:
+                                default:
+                                - ReadWriteOnce
+                                description: Access modes
+                                items:
+                                  type: string
+                                type: array
+                              enabled:
+                                default: false
+                                description: Enable auto-creation
+                                type: boolean
+                              size:
+                                default: 100Gi
+                                description: Storage size (e.g., "100Gi")
+                                type: string
+                              storageClassName:
+                                description: Storage class name
+                                nullable: true
+                                type: string
+                            type: object
+                          subPath:
+                            description: Sub-path within the PVC
+                            nullable: true
+                            type: string
+                        required:
+                        - claimName
+                        type: object
+                      s3:
+                        description: S3 storage configuration
+                        nullable: true
+                        properties:
+                          bucket:
+                            description: S3 bucket name
+                            type: string
+                          credentialsSecret:
+                            description: Credentials secret reference
+                            properties:
+                              accessKeyIdKey:
+                                default: AWS_ACCESS_KEY_ID
+                                description: Access key ID key in secret
+                                type: string
+                              name:
+                                description: Secret name
+                                type: string
+                              secretAccessKeyKey:
+                                default: AWS_SECRET_ACCESS_KEY
+                                description: Secret access key key in secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          endpoint:
+                            description: Custom endpoint (for MinIO, Ceph, etc.)
+                            nullable: true
+                            type: string
+                          prefix:
+                            description: Path prefix within bucket
+                            nullable: true
+                            type: string
+                          region:
+                            description: AWS region
+                            type: string
+                        required:
+                        - bucket
+                        - credentialsSecret
+                        - region
+                        type: object
+                      storageType:
+                        default: pvc
+                        description: Storage type (pvc, s3, azure, gcs)
+                        type: string
+                    type: object
+                required:
+                - name
+                type: object
+              circuitBreaker:
+                description: Circuit breaker configuration
+                nullable: true
+                properties:
+                  enabled:
+                    default: true
+                    description: Enable circuit breaker
+                    type: boolean
+                  failureThreshold:
+                    default: 5
+                    description: Failure threshold before opening circuit
+                    format: uint32
+                    minimum: 0.0
+                    type: integer
+                  operationTimeoutMs:
+                    default: 30000
+                    description: Operation timeout (milliseconds)
+                    format: uint64
+                    minimum: 0.0
+                    type: integer
+                  resetTimeoutSecs:
+                    default: 60
+                    description: Time to wait before attempting recovery (seconds)
+                    format: uint64
+                    minimum: 0.0
+                    type: integer
+                  successThreshold:
+                    default: 3
+                    description: Success threshold to close circuit
+                    format: uint32
+                    minimum: 0.0
+                    type: integer
+                type: object
+              dryRun:
+                default: false
+                description: Dry run mode (validate without executing)
+                type: boolean
+              kafkaCluster:
+                description: Target Kafka cluster (can differ from backup source)
+                properties:
+                  bootstrapServers:
+                    description: Bootstrap servers
+                    items:
+                      type: string
+                    type: array
+                  saslSecret:
+                    description: SASL configuration secret reference
+                    nullable: true
+                    properties:
+                      mechanism:
+                        description: SASL mechanism (PLAIN, SCRAM-SHA-256, SCRAM-SHA-512)
+                        type: string
+                      name:
+                        description: Secret name
+                        type: string
+                      passwordKey:
+                        default: password
+                        description: Password key in secret
+                        type: string
+                      usernameKey:
+                        default: username
+                        description: Username key in secret
+                        type: string
+                    required:
+                    - mechanism
+                    - name
+                    type: object
+                  securityProtocol:
+                    default: PLAINTEXT
+                    description: Security protocol (PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL)
+                    type: string
+                  tlsSecret:
+                    description: TLS configuration secret reference
+                    nullable: true
+                    properties:
+                      caKey:
+                        default: ca.crt
+                        description: CA certificate key in secret
+                        type: string
+                      certKey:
+                        description: Client certificate key in secret
+                        nullable: true
+                        type: string
+                      keyKey:
+                        description: Client key key in secret
+                        nullable: true
+                        type: string
+                      name:
+                        description: Secret name
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - bootstrapServers
+                type: object
+              offsetReset:
+                description: Consumer offset reset configuration
+                nullable: true
+                properties:
+                  consumerGroups:
+                    description: Consumer groups to reset
+                    items:
+                      type: string
+                    type: array
+                  enabled:
+                    default: false
+                    description: Enable offset reset as part of restore
+                    type: boolean
+                  strategy:
+                    default: manual
+                    description: Reset strategy (manual, auto, dry_run)
+                    type: string
+                required:
+                - consumerGroups
+                type: object
+              partitionMapping:
+                additionalProperties:
+                  format: int32
+                  type: integer
+                default: {}
+                description: Partition remapping (source -> target)
+                type: object
+              pitr:
+                description: Point-in-time recovery configuration
+                nullable: true
+                properties:
+                  endTime:
+                    description: 'Alternative: End time as ISO 8601 string'
+                    format: date-time
+                    nullable: true
+                    type: string
+                  endTimestamp:
+                    description: End timestamp (epoch milliseconds)
+                    format: int64
+                    nullable: true
+                    type: integer
+                  startTime:
+                    description: 'Alternative: Start time as ISO 8601 string'
+                    format: date-time
+                    nullable: true
+                    type: string
+                  startTimestamp:
+                    description: Start timestamp (epoch milliseconds)
+                    format: int64
+                    nullable: true
+                    type: integer
+                type: object
+              rateLimiting:
+                description: Rate limiting configuration
+                nullable: true
+                properties:
+                  bytesPerSec:
+                    default: 0
+                    description: Maximum bytes per second (0 = unlimited)
+                    format: uint64
+                    minimum: 0.0
+                    type: integer
+                  maxConcurrentPartitions:
+                    default: 4
+                    description: Maximum concurrent partitions
+                    format: uint
+                    minimum: 0.0
+                    type: integer
+                  recordsPerSec:
+                    default: 0
+                    description: Maximum records per second (0 = unlimited)
+                    format: uint64
+                    minimum: 0.0
+                    type: integer
+                type: object
+              rollback:
+                description: Rollback safety configuration
+                nullable: true
+                properties:
+                  autoRollbackOnFailure:
+                    default: false
+                    description: Auto-rollback on failure
+                    type: boolean
+                  snapshotBeforeRestore:
+                    default: true
+                    description: Create snapshot before restore
+                    type: boolean
+                  snapshotRetentionHours:
+                    default: 24
+                    description: Snapshot retention (hours)
+                    format: uint32
+                    minimum: 0.0
+                    type: integer
+                  snapshotStorage:
+                    description: Snapshot storage (defaults to operator storage)
+                    nullable: true
+                    properties:
+                      pvcName:
+                        description: PVC name for snapshots
+                        type: string
+                      subPath:
+                        description: Sub-path within PVC
+                        nullable: true
+                        type: string
+                    required:
+                    - pvcName
+                    type: object
+                type: object
+              topicMapping:
+                additionalProperties:
+                  type: string
+                default: {}
+                description: Topic remapping (source -> target)
+                type: object
+              topics:
+                default: []
+                description: Topics to restore (empty = all topics from backup)
+                items:
+                  type: string
+                type: array
+            required:
+            - backupRef
+            - kafkaCluster
+            type: object
+          status:
+            description: KafkaRestore status
+            nullable: true
+            properties:
+              bytesRestored:
+                description: Bytes restored
+                format: uint64
+                minimum: 0.0
+                nullable: true
+                type: integer
+              completionTime:
+                description: Completion time
+                format: date-time
+                nullable: true
+                type: string
+              conditions:
+                description: Status conditions
+                items:
+                  description: Status condition
+                  properties:
+                    lastTransitionTime:
+                      description: Last transition time
+                      format: date-time
+                      type: string
+                    message:
+                      description: Human-readable message
+                      nullable: true
+                      type: string
+                    reason:
+                      description: Reason for the condition
+                      nullable: true
+                      type: string
+                    status:
+                      description: Status (True, False, Unknown)
+                      type: string
+                    type:
+                      description: Condition type
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              currentTopic:
+                description: Current topic being restored
+                nullable: true
+                type: string
+              etaMs:
+                description: ETA (milliseconds)
+                format: uint64
+                minimum: 0.0
+                nullable: true
+                type: integer
+              message:
+                description: Human-readable message
+                nullable: true
+                type: string
+              observedGeneration:
+                description: Observed generation
+                format: int64
+                nullable: true
+                type: integer
+              offsetMappingPath:
+                description: Offset mapping path (for post-restore offset reset)
+                nullable: true
+                type: string
+              phase:
+                description: Current phase (Pending, Running, Completed, Failed, RolledBack)
+                nullable: true
+                type: string
+              progressPercent:
+                description: Progress percentage (0-100)
+                format: double
+                nullable: true
+                type: number
+              recordsRestored:
+                description: Records restored
+                format: uint64
+                minimum: 0.0
+                nullable: true
+                type: integer
+              rollback:
+                description: Rollback status
+                nullable: true
+                properties:
+                  expiresAt:
+                    description: Snapshot expiry time
+                    format: date-time
+                    nullable: true
+                    type: string
+                  rollbackAvailable:
+                    description: Whether rollback is available
+                    type: boolean
+                  snapshotId:
+                    description: Snapshot ID
+                    type: string
+                  snapshotPath:
+                    description: Snapshot storage path
+                    type: string
+                  snapshotTime:
+                    description: Snapshot time
+                    format: date-time
+                    type: string
+                required:
+                - rollbackAvailable
+                - snapshotId
+                - snapshotPath
+                - snapshotTime
+                type: object
+              segmentsProcessed:
+                description: Segments processed
+                format: uint64
+                minimum: 0.0
+                nullable: true
+                type: integer
+              startTime:
+                description: Start time
+                format: date-time
+                nullable: true
+                type: string
+              throughputRecordsPerSec:
+                description: Throughput (records per second)
+                format: double
+                nullable: true
+                type: number
+            type: object
+        required:
+        - spec
+        title: KafkaRestore
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkaoffsetresets.kafka.oso.sh
+spec:
+  group: kafka.oso.sh
+  names:
+    categories: []
+    kind: KafkaOffsetReset
+    plural: kafkaoffsetresets
+    shortNames:
+    - kor
+    singular: kafkaoffsetreset
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.groupsReset
+      name: Groups
+      type: integer
+    - jsonPath: .status.groupsFailed
+      name: Failed
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for KafkaOffsetResetSpec via `CustomResource`
+        properties:
+          spec:
+            description: KafkaOffsetReset resource specification
+            properties:
+              consumerGroups:
+                description: Consumer groups to reset
+                items:
+                  type: string
+                type: array
+              continueOnError:
+                default: false
+                description: Continue on error (don't fail entire operation if one group fails)
+                type: boolean
+              dryRun:
+                default: false
+                description: Dry run mode
+                type: boolean
+              kafkaCluster:
+                description: Target Kafka cluster
+                properties:
+                  bootstrapServers:
+                    description: Bootstrap servers
+                    items:
+                      type: string
+                    type: array
+                  saslSecret:
+                    description: SASL configuration secret reference
+                    nullable: true
+                    properties:
+                      mechanism:
+                        description: SASL mechanism (PLAIN, SCRAM-SHA-256, SCRAM-SHA-512)
+                        type: string
+                      name:
+                        description: Secret name
+                        type: string
+                      passwordKey:
+                        default: password
+                        description: Password key in secret
+                        type: string
+                      usernameKey:
+                        default: username
+                        description: Username key in secret
+                        type: string
+                    required:
+                    - mechanism
+                    - name
+                    type: object
+                  securityProtocol:
+                    default: PLAINTEXT
+                    description: Security protocol (PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL)
+                    type: string
+                  tlsSecret:
+                    description: TLS configuration secret reference
+                    nullable: true
+                    properties:
+                      caKey:
+                        default: ca.crt
+                        description: CA certificate key in secret
+                        type: string
+                      certKey:
+                        description: Client certificate key in secret
+                        nullable: true
+                        type: string
+                      keyKey:
+                        description: Client key key in secret
+                        nullable: true
+                        type: string
+                      name:
+                        description: Secret name
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - bootstrapServers
+                type: object
+              offsetMappingRef:
+                description: Reference to offset mapping from a restore operation
+                nullable: true
+                properties:
+                  path:
+                    description: Direct path to offset mapping file
+                    nullable: true
+                    type: string
+                  pvcName:
+                    description: PVC containing the mapping
+                    nullable: true
+                    type: string
+                  restoreName:
+                    description: KafkaRestore resource name
+                    nullable: true
+                    type: string
+                type: object
+              parallelism:
+                default: 50
+                description: Parallelism for bulk reset
+                format: uint
+                minimum: 0.0
+                type: integer
+              resetOffset:
+                description: Target offset for to-offset strategy
+                format: int64
+                nullable: true
+                type: integer
+              resetStrategy:
+                description: Reset strategy
+                enum:
+                - to-earliest
+                - to-latest
+                - to-timestamp
+                - to-offset
+                - from-mapping
+                type: string
+              resetTimestamp:
+                description: Target timestamp for to-timestamp strategy (epoch ms)
+                format: int64
+                nullable: true
+                type: integer
+              snapshotBeforeReset:
+                default: true
+                description: Snapshot before reset for rollback
+                type: boolean
+              topics:
+                default: []
+                description: Topics to reset (empty = all topics for the group)
+                items:
+                  type: string
+                type: array
+            required:
+            - consumerGroups
+            - kafkaCluster
+            - resetStrategy
+            type: object
+          status:
+            description: KafkaOffsetReset status
+            nullable: true
+            properties:
+              completionTime:
+                description: Completion time
+                format: date-time
+                nullable: true
+                type: string
+              conditions:
+                description: Status conditions
+                items:
+                  description: Status condition
+                  properties:
+                    lastTransitionTime:
+                      description: Last transition time
+                      format: date-time
+                      type: string
+                    message:
+                      description: Human-readable message
+                      nullable: true
+                      type: string
+                    reason:
+                      description: Reason for the condition
+                      nullable: true
+                      type: string
+                    status:
+                      description: Status (True, False, Unknown)
+                      type: string
+                    type:
+                      description: Condition type
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              duration:
+                description: Duration (human-readable)
+                nullable: true
+                type: string
+              groupResults:
+                description: Per-group results
+                items:
+                  description: Per-group reset result
+                  properties:
+                    error:
+                      description: Error message if failed
+                      nullable: true
+                      type: string
+                    groupId:
+                      description: Consumer group ID
+                      type: string
+                    partitionsReset:
+                      description: Number of partitions reset
+                      format: uint
+                      minimum: 0.0
+                      nullable: true
+                      type: integer
+                    success:
+                      description: Success status
+                      type: boolean
+                  required:
+                  - groupId
+                  - success
+                  type: object
+                type: array
+              groupsFailed:
+                description: Groups that failed
+                format: uint
+                minimum: 0.0
+                nullable: true
+                type: integer
+              groupsReset:
+                description: Groups successfully reset
+                format: uint
+                minimum: 0.0
+                nullable: true
+                type: integer
+              groupsTotal:
+                description: Total groups to reset
+                format: uint
+                minimum: 0.0
+                nullable: true
+                type: integer
+              message:
+                description: Human-readable message
+                nullable: true
+                type: string
+              observedGeneration:
+                description: Observed generation
+                format: int64
+                nullable: true
+                type: integer
+              phase:
+                description: Current phase (Pending, Running, Completed, Failed, PartiallyCompleted)
+                nullable: true
+                type: string
+              snapshotId:
+                description: Snapshot ID for rollback
+                nullable: true
+                type: string
+              snapshotPath:
+                description: Snapshot path
+                nullable: true
+                type: string
+              startTime:
+                description: Start time
+                format: date-time
+                nullable: true
+                type: string
+            type: object
+        required:
+        - spec
+        title: KafkaOffsetReset
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkaoffsetrollbacks.kafka.oso.sh
+spec:
+  group: kafka.oso.sh
+  names:
+    categories: []
+    kind: KafkaOffsetRollback
+    plural: kafkaoffsetrollbacks
+    shortNames:
+    - korb
+    singular: kafkaoffsetrollback
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.groupsRolledBack
+      name: Groups
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for KafkaOffsetRollbackSpec via `CustomResource`
+        properties:
+          spec:
+            description: KafkaOffsetRollback resource specification
+            properties:
+              consumerGroups:
+                default: []
+                description: Consumer groups to rollback (empty = all groups in snapshot)
+                items:
+                  type: string
+                type: array
+              dryRun:
+                default: false
+                description: Dry run mode
+                type: boolean
+              kafkaCluster:
+                description: Target Kafka cluster
+                properties:
+                  bootstrapServers:
+                    description: Bootstrap servers
+                    items:
+                      type: string
+                    type: array
+                  saslSecret:
+                    description: SASL configuration secret reference
+                    nullable: true
+                    properties:
+                      mechanism:
+                        description: SASL mechanism (PLAIN, SCRAM-SHA-256, SCRAM-SHA-512)
+                        type: string
+                      name:
+                        description: Secret name
+                        type: string
+                      passwordKey:
+                        default: password
+                        description: Password key in secret
+                        type: string
+                      usernameKey:
+                        default: username
+                        description: Username key in secret
+                        type: string
+                    required:
+                    - mechanism
+                    - name
+                    type: object
+                  securityProtocol:
+                    default: PLAINTEXT
+                    description: Security protocol (PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL)
+                    type: string
+                  tlsSecret:
+                    description: TLS configuration secret reference
+                    nullable: true
+                    properties:
+                      caKey:
+                        default: ca.crt
+                        description: CA certificate key in secret
+                        type: string
+                      certKey:
+                        description: Client certificate key in secret
+                        nullable: true
+                        type: string
+                      keyKey:
+                        description: Client key key in secret
+                        nullable: true
+                        type: string
+                      name:
+                        description: Secret name
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - bootstrapServers
+                type: object
+              snapshotRef:
+                description: Reference to snapshot to restore from
+                properties:
+                  name:
+                    description: Snapshot name/ID
+                    type: string
+                  offsetResetRef:
+                    description: Reference to KafkaOffsetReset that created the snapshot
+                    nullable: true
+                    type: string
+                  path:
+                    description: Path to snapshot file within PVC
+                    nullable: true
+                    type: string
+                  pvcName:
+                    description: PVC containing the snapshot
+                    nullable: true
+                    type: string
+                  restoreRef:
+                    description: Reference to KafkaRestore that created the snapshot
+                    nullable: true
+                    type: string
+                required:
+                - name
+                type: object
+              verifyAfterRollback:
+                default: true
+                description: Verify after rollback
+                type: boolean
+            required:
+            - kafkaCluster
+            - snapshotRef
+            type: object
+          status:
+            description: KafkaOffsetRollback status
+            nullable: true
+            properties:
+              completionTime:
+                description: Completion time
+                format: date-time
+                nullable: true
+                type: string
+              conditions:
+                description: Status conditions
+                items:
+                  description: Status condition
+                  properties:
+                    lastTransitionTime:
+                      description: Last transition time
+                      format: date-time
+                      type: string
+                    message:
+                      description: Human-readable message
+                      nullable: true
+                      type: string
+                    reason:
+                      description: Reason for the condition
+                      nullable: true
+                      type: string
+                    status:
+                      description: Status (True, False, Unknown)
+                      type: string
+                    type:
+                      description: Condition type
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              groupsFailed:
+                description: Groups that failed
+                format: uint
+                minimum: 0.0
+                nullable: true
+                type: integer
+              groupsRolledBack:
+                description: Groups successfully rolled back
+                format: uint
+                minimum: 0.0
+                nullable: true
+                type: integer
+              message:
+                description: Human-readable message
+                nullable: true
+                type: string
+              observedGeneration:
+                description: Observed generation
+                format: int64
+                nullable: true
+                type: integer
+              phase:
+                description: Current phase (Pending, Running, Completed, Failed, PartiallyCompleted)
+                nullable: true
+                type: string
+              startTime:
+                description: Start time
+                format: date-time
+                nullable: true
+                type: string
+              verification:
+                description: Verification result
+                nullable: true
+                properties:
+                  allMatched:
+                    description: Whether all offsets matched expected values
+                    type: boolean
+                  matchedGroups:
+                    description: Groups that matched
+                    format: uint
+                    minimum: 0.0
+                    type: integer
+                  mismatchedGroups:
+                    description: Groups with mismatches
+                    items:
+                      type: string
+                    type: array
+                  totalGroups:
+                    description: Total groups verified
+                    format: uint
+                    minimum: 0.0
+                    type: integer
+                required:
+                - allMatched
+                - matchedGroups
+                - totalGroups
+                type: object
+            type: object
+        required:
+        - spec
+        title: KafkaOffsetRollback
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/kafka-backup-operator/templates/NOTES.txt
+++ b/charts/kafka-backup-operator/templates/NOTES.txt
@@ -1,0 +1,41 @@
+Thank you for installing {{ .Chart.Name }}!
+
+Your release is named: {{ .Release.Name }}
+
+To verify the installation, run:
+
+  kubectl get pods -l "app.kubernetes.io/name={{ include "kafka-backup-operator.name" . }},app.kubernetes.io/instance={{ .Release.Name }}"
+
+The operator is now watching for the following custom resources:
+  - KafkaBackup
+  - KafkaRestore
+  - KafkaOffsetReset
+  - KafkaOffsetRollback
+
+To create a backup, apply a KafkaBackup resource:
+
+  apiVersion: kafka.oso.sh/v1alpha1
+  kind: KafkaBackup
+  metadata:
+    name: my-backup
+  spec:
+    topics:
+      - "my-topic"
+    kafkaCluster:
+      bootstrapServers:
+        - "kafka:9092"
+    storage:
+      storageType: pvc
+      pvc:
+        claimName: backup-storage
+    schedule: "0 2 * * *"  # Daily at 2 AM
+
+For more information, visit:
+  https://github.com/osodevops/kafka-backup-operator
+
+{{- if .Values.metrics.enabled }}
+
+Metrics are available at:
+  kubectl port-forward svc/{{ include "kafka-backup-operator.fullname" . }}-metrics 8080:8080
+  curl http://localhost:8080/metrics
+{{- end }}

--- a/charts/kafka-backup-operator/templates/_helpers.tpl
+++ b/charts/kafka-backup-operator/templates/_helpers.tpl
@@ -1,0 +1,70 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kafka-backup-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kafka-backup-operator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kafka-backup-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "kafka-backup-operator.labels" -}}
+helm.sh/chart: {{ include "kafka-backup-operator.chart" . }}
+{{ include "kafka-backup-operator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kafka-backup-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kafka-backup-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "kafka-backup-operator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "kafka-backup-operator.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the proper image name
+*/}}
+{{- define "kafka-backup-operator.image" -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end }}

--- a/charts/kafka-backup-operator/templates/clusterrole.yaml
+++ b/charts/kafka-backup-operator/templates/clusterrole.yaml
@@ -1,0 +1,147 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kafka-backup-operator.fullname" . }}
+  labels:
+    {{- include "kafka-backup-operator.labels" . | nindent 4 }}
+rules:
+  # Core resources
+  - apiGroups: [""]
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups: [""]
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups: [""]
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+
+  # Custom resources - KafkaBackup
+  - apiGroups: ["kafka.oso.sh"]
+    resources:
+      - kafkabackups
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups: ["kafka.oso.sh"]
+    resources:
+      - kafkabackups/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups: ["kafka.oso.sh"]
+    resources:
+      - kafkabackups/finalizers
+    verbs:
+      - update
+
+  # Custom resources - KafkaRestore
+  - apiGroups: ["kafka.oso.sh"]
+    resources:
+      - kafkarestores
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups: ["kafka.oso.sh"]
+    resources:
+      - kafkarestores/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups: ["kafka.oso.sh"]
+    resources:
+      - kafkarestores/finalizers
+    verbs:
+      - update
+
+  # Custom resources - KafkaOffsetReset
+  - apiGroups: ["kafka.oso.sh"]
+    resources:
+      - kafkaoffsetresets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups: ["kafka.oso.sh"]
+    resources:
+      - kafkaoffsetresets/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups: ["kafka.oso.sh"]
+    resources:
+      - kafkaoffsetresets/finalizers
+    verbs:
+      - update
+
+  # Custom resources - KafkaOffsetRollback
+  - apiGroups: ["kafka.oso.sh"]
+    resources:
+      - kafkaoffsetrollbacks
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups: ["kafka.oso.sh"]
+    resources:
+      - kafkaoffsetrollbacks/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups: ["kafka.oso.sh"]
+    resources:
+      - kafkaoffsetrollbacks/finalizers
+    verbs:
+      - update
+
+  {{- if .Values.leaderElection.enabled }}
+  # Coordination for leader election
+  - apiGroups: ["coordination.k8s.io"]
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  {{- end }}

--- a/charts/kafka-backup-operator/templates/clusterrolebinding.yaml
+++ b/charts/kafka-backup-operator/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kafka-backup-operator.fullname" . }}
+  labels:
+    {{- include "kafka-backup-operator.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "kafka-backup-operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "kafka-backup-operator.fullname" . }}

--- a/charts/kafka-backup-operator/templates/deployment.yaml
+++ b/charts/kafka-backup-operator/templates/deployment.yaml
@@ -1,0 +1,90 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kafka-backup-operator.fullname" . }}
+  labels:
+    {{- include "kafka-backup-operator.labels" . | nindent 4 }}
+    app.kubernetes.io/component: controller
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "kafka-backup-operator.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "kafka-backup-operator.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: controller
+        {{- if .Values.azureWorkloadIdentity.enabled }}
+        azure.workload.identity/use: "true"
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "kafka-backup-operator.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: operator
+          image: {{ include "kafka-backup-operator.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: metrics
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: RUST_LOG
+              value: {{ .Values.logging.level | quote }}
+            - name: OPERATOR_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            {{- if .Values.leaderElection.enabled }}
+            - name: LEADER_ELECTION_ENABLED
+              value: "true"
+            - name: LEADER_ELECTION_LEASE_DURATION
+              value: {{ .Values.leaderElection.leaseDuration | quote }}
+            - name: LEADER_ELECTION_RENEW_DEADLINE
+              value: {{ .Values.leaderElection.renewDeadline | quote }}
+            - name: LEADER_ELECTION_RETRY_PERIOD
+              value: {{ .Values.leaderElection.retryPeriod | quote }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: metrics
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: metrics
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+      terminationGracePeriodSeconds: 30
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/kafka-backup-operator/templates/service.yaml
+++ b/charts/kafka-backup-operator/templates/service.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kafka-backup-operator.fullname" . }}-metrics
+  labels:
+    {{- include "kafka-backup-operator.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  selector:
+    {{- include "kafka-backup-operator.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/kafka-backup-operator/templates/serviceaccount.yaml
+++ b/charts/kafka-backup-operator/templates/serviceaccount.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kafka-backup-operator.serviceAccountName" . }}
+  labels:
+    {{- include "kafka-backup-operator.labels" . | nindent 4 }}
+  {{- if or .Values.serviceAccount.annotations .Values.azureWorkloadIdentity.enabled }}
+  annotations:
+    {{- if .Values.azureWorkloadIdentity.enabled }}
+    azure.workload.identity/client-id: {{ required "azureWorkloadIdentity.clientId is required when azureWorkloadIdentity.enabled is true" .Values.azureWorkloadIdentity.clientId | quote }}
+    {{- end }}
+    {{- with .Values.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/kafka-backup-operator/templates/servicemonitor.yaml
+++ b/charts/kafka-backup-operator/templates/servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "kafka-backup-operator.fullname" . }}
+  labels:
+    {{- include "kafka-backup-operator.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "kafka-backup-operator.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      path: /metrics
+{{- end }}

--- a/charts/kafka-backup-operator/values.yaml
+++ b/charts/kafka-backup-operator/values.yaml
@@ -1,0 +1,102 @@
+# Default values for kafka-backup-operator
+
+# Number of replicas
+replicaCount: 1
+
+image:
+  repository: ghcr.io/osodevops/kafka-backup-operator
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  # For Azure Workload Identity, add:
+  #   azure.workload.identity/client-id: "<managed-identity-client-id>"
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# Azure Workload Identity configuration
+# When enabled, the operator can authenticate to Azure services using federated identity tokens
+# instead of storing credentials in Kubernetes secrets
+azureWorkloadIdentity:
+  # Enable Azure Workload Identity support
+  enabled: false
+  # The client ID of the Azure Managed Identity
+  # This should match the identity federated with this service account
+  clientId: ""
+
+# Pod annotations
+podAnnotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "8080"
+  prometheus.io/path: "/metrics"
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 1000
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+# Metrics service configuration
+service:
+  type: ClusterIP
+  port: 8080
+  annotations: {}
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+nodeSelector:
+  kubernetes.io/os: linux
+
+tolerations: []
+
+affinity: {}
+
+# Logging configuration
+logging:
+  level: "info,kafka_backup_operator=debug"
+  format: json
+
+# Metrics configuration
+metrics:
+  enabled: true
+  serviceMonitor:
+    enabled: false
+    interval: 30s
+    scrapeTimeout: 10s
+    labels: {}
+
+# CRD installation
+crds:
+  # Install CRDs with the chart
+  install: true
+  # Keep CRDs on chart uninstall
+  keep: true
+
+# Leader election configuration (for HA deployments)
+leaderElection:
+  enabled: false
+  leaseDuration: 15s
+  renewDeadline: 10s
+  retryPeriod: 2s


### PR DESCRIPTION
## Summary

Automated sync of `kafka-backup-operator` Helm chart.

**Chart Version:** `0.1.1`
**App Version:** `0.1.0`
**Source Commit:** [`d401c4ce38f1494bb9f8855ecd6d6809303e3b12`](https://github.com/osodevops/kafka-backup-operator/commit/d401c4ce38f1494bb9f8855ecd6d6809303e3b12)

---
*Auto-generated by [Helm Chart Sync Workflow](https://github.com/osodevops/kafka-backup-operator/actions/runs/20132298558)*