### PR TITLE
chore(kafka-backup-operator): sync chart v0.2.5

### DIFF
--- a/charts/kafka-backup-operator/Chart.yaml
+++ b/charts/kafka-backup-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kafka-backup-operator
 description: A Kubernetes operator for managing Kafka backup and restore operations
 type: application
-version: 0.2.1
-appVersion: "0.2.1"
+version: 0.2.5
+appVersion: "0.2.5"
 home: https://github.com/osodevops/kafka-backup-operator
 sources:
   - https://github.com/osodevops/kafka-backup-operator

--- a/charts/kafka-backup-operator/crds/all.yaml
+++ b/charts/kafka-backup-operator/crds/all.yaml
@@ -1,3 +1,5 @@
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.42s
+     Running `target/debug/crdgen`
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -787,6 +789,15 @@ spec:
                     minimum: 0.0
                     type: integer
                 type: object
+              createTopics:
+                default: false
+                description: Create missing topics during restore When enabled, topics that exist in the backup but not in the target cluster will be automatically created before restoring data.
+                type: boolean
+              defaultReplicationFactor:
+                description: Default replication factor for auto-created topics If not specified, the broker's default replication factor is used.
+                format: int16
+                nullable: true
+                type: integer
               dryRun:
                 default: false
                 description: Dry run mode (validate without executing)

--- a/charts/kafka-backup-operator/crds/all.yaml
+++ b/charts/kafka-backup-operator/crds/all.yaml
@@ -1,5 +1,3 @@
-    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.42s
-     Running `target/debug/crdgen`
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/charts/kafka-backup-operator/templates/deployment.yaml
+++ b/charts/kafka-backup-operator/templates/deployment.yaml
@@ -75,6 +75,12 @@ spec:
             failureThreshold: 3
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
       terminationGracePeriodSeconds: 30
       {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
## Summary

Automated sync of `kafka-backup-operator` Helm chart.

**Chart Version:** `0.2.5`
**App Version:** `0.2.5`
**Source Commit:** [`f9036f26ae702bd0708992621a4a47a85f48c8c4`](https://github.com/osodevops/kafka-backup-operator/commit/f9036f26ae702bd0708992621a4a47a85f48c8c4)

---
*Auto-generated by [Helm Chart Sync Workflow](https://github.com/osodevops/kafka-backup-operator/actions/runs/20730282554)*