### PR TITLE
feat(kafka-connect): allow per-connector debezium database overrides

### DIFF
--- a/charts/kafka-connect/Chart.yaml
+++ b/charts/kafka-connect/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/kafka-connect/templates/connector.yaml
+++ b/charts/kafka-connect/templates/connector.yaml
@@ -49,11 +49,13 @@ spec:
     sasl.jaas.config: {{ $.Values.kafka.saslJaasConfig }}
     sasl.client.callback.handler.class: {{ $.Values.kafka.saslClientCallbackHandler }}
     schema.history.internal.kafka.bootstrap.servers: {{ $.Values.kafka.bootstrapServers }}
-    database.hostname: {{ $.Values.debezium_database.hostname }}
-    database.user: {{ $.Values.debezium_database.user }}
-    database.password: {{ $.Values.debezium_database.password }}
-    database.port: {{ $.Values.debezium_database.port }}
-    database.dbname: {{ $.Values.debezium_database.db_name }}
+
+    {{- $db := $connector_config.database | default dict }}
+    database.hostname: {{ $db.hostname | default $.Values.debezium_database.hostname }}
+    database.user: {{ $db.user | default $.Values.debezium_database.user }}
+    database.password: {{ $db.password | default $.Values.debezium_database.password }}
+    database.port: {{ $db.port | default $.Values.debezium_database.port }}
+    database.dbname: {{ $db.db_name | default $.Values.debezium_database.db_name }}
     schema.history.internal.producer.sasl.client.callback.handler.class: {{ $.Values.kafka.saslClientCallbackHandler }}
     schema.history.internal.producer.security.protocol: {{ $.Values.kafka.securityProtocol }}
     schema.history.internal.producer.sasl.mechanism: {{ $.Values.kafka.saslMechanism }}
@@ -71,7 +73,9 @@ spec:
     {{ $key }}: {{ $value }}
     {{- end }}
     {{- range $key, $value := $connector_config }}
+    {{- if ne $key "database" }}
     {{ $key }}: {{ $value }}
+    {{- end }}
     {{- end }}
 ---
 {{- end }}


### PR DESCRIPTION
This change updates the `kafka-connect` Helm chart to support per-connector Debezium database configuration, while preserving existing behaviour via global defaults.

Currently, all Debezium connectors rendered by the chart are made to use a single, global `debezium_database` configuration (hostname, credentials, db name, etc.). This made it impossible to run multiple Debezium connectors against different source databases within the same Kafka Connect deployment.

This PR introduces a backward-compatible mechanism to override database connection settings per connector.

