### PR TITLE
chore(kafka-backup-operator): sync chart v0.2.6

### DIFF
--- a/charts/kafka-backup-operator/Chart.yaml
+++ b/charts/kafka-backup-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kafka-backup-operator
 description: A Kubernetes operator for managing Kafka backup and restore operations
 type: application
-version: 0.2.5
-appVersion: "0.2.5"
+version: 0.2.6
+appVersion: "0.2.6"
 home: https://github.com/osodevops/kafka-backup-operator
 sources:
   - https://github.com/osodevops/kafka-backup-operator

--- a/charts/kafka-backup-operator/crds/all.yaml
+++ b/charts/kafka-backup-operator/crds/all.yaml
@@ -168,6 +168,41 @@ spec:
                 required:
                 - bootstrapServers
                 type: object
+              metrics:
+                description: Metrics configuration
+                nullable: true
+                properties:
+                  bindAddress:
+                    default: 0.0.0.0
+                    description: 'Bind address for metrics server (default: "0.0.0.0")'
+                    type: string
+                  enabled:
+                    default: true
+                    description: 'Enable metrics collection (default: true)'
+                    type: boolean
+                  maxPartitionLabels:
+                    default: 100
+                    description: 'Maximum partition labels to prevent cardinality explosion (default: 100)'
+                    format: uint
+                    minimum: 0.0
+                    type: integer
+                  path:
+                    default: /metrics
+                    description: 'Metrics endpoint path (default: "/metrics")'
+                    type: string
+                  port:
+                    default: 9090
+                    description: 'Port for metrics HTTP server (default: 9090)'
+                    format: uint16
+                    minimum: 0.0
+                    type: integer
+                  updateIntervalMs:
+                    default: 500
+                    description: 'Metrics update interval in milliseconds (default: 500)'
+                    format: uint64
+                    minimum: 0.0
+                    type: integer
+                type: object
               rateLimiting:
                 description: Rate limiting configuration
                 nullable: true


### PR DESCRIPTION
## Summary

Automated sync of `kafka-backup-operator` Helm chart.

**Chart Version:** `0.2.6`
**App Version:** `0.2.6`
**Source Commit:** [`fb82315051d1c9271a9133326d897835d61ac317`](https://github.com/osodevops/kafka-backup-operator/commit/fb82315051d1c9271a9133326d897835d61ac317)

---
*Auto-generated by [Helm Chart Sync Workflow](https://github.com/osodevops/kafka-backup-operator/actions/runs/21161329517)*