### PR TITLE
fix(courselit): Make MongoDB operator conditional on mongodb.enabled

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -36,6 +36,7 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: |
           helm repo add valkey https://valkey-io.github.io/valkey-helm
+          helm repo add mongodb https://mongodb.github.io/helm-charts
           helm repo update
 
       - name: Build chart dependencies

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -32,6 +32,22 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Add Helm repositories
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+          helm repo add valkey https://valkey-io.github.io/valkey-helm
+          helm repo update
+
+      - name: Build chart dependencies
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+          for chart in $(ct list-changed --target-branch ${{ github.event.repository.default_branch }}); do
+            if [ -f "$chart/Chart.yaml" ]; then
+              echo "Building dependencies for $chart"
+              helm dependency build "$chart"
+            fi
+          done
+
       - name: Run chart-testing (lint)
         if: steps.list-changed.outputs.changed == 'true'
         run: ct lint --target-branch ${{ github.event.repository.default_branch }}

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Run chart-testing (lint)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct lint --target-branch ${{ github.event.repository.default_branch }}
+        run: ct lint --config ct.yaml --target-branch ${{ github.event.repository.default_branch }}
 
       - name: Create kind cluster
         if: steps.list-changed.outputs.changed == 'true'
@@ -58,4 +58,4 @@ jobs:
 
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct install --target-branch ${{ github.event.repository.default_branch }}
+        run: ct install --config ct.yaml --target-branch ${{ github.event.repository.default_branch }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,6 +29,7 @@ jobs:
       - name: Add Helm repositories
         run: |
           helm repo add valkey https://valkey-io.github.io/valkey-helm
+          helm repo add mongodb https://mongodb.github.io/helm-charts
           helm repo update
 
       - name: Build chart dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,25 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
+      - name: Install Helm
+        uses: azure/setup-helm@v4.2.0
+        with:
+          version: v3.14.4
+
+      - name: Add Helm repositories
+        run: |
+          helm repo add valkey https://valkey-io.github.io/valkey-helm
+          helm repo update
+
+      - name: Build chart dependencies
+        run: |
+          for chart in charts/*/; do
+            if [ -f "${chart}Chart.yaml" ] && grep -q "dependencies:" "${chart}Chart.yaml"; then
+              echo "Building dependencies for $chart"
+              helm dependency build "$chart" || echo "No dependencies or already built for $chart"
+            fi
+          done
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 test*
+charts/courselit/charts/valkey-0.9.2.tgz

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 test*
 charts/courselit/charts/valkey-0.9.2.tgz
+charts/courselit/charts/community-operator-0.10.0.tgz

--- a/charts/courselit/.helmignore
+++ b/charts/courselit/.helmignore
@@ -1,0 +1,32 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# CI/CD
+.github/
+.gitlab-ci.yml
+.travis.yml
+# Documentation
+README.md.gotmpl
+OWNERS
+# Test files
+ci/

--- a/charts/courselit/Chart.lock
+++ b/charts/courselit/Chart.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: valkey
   repository: https://valkey-io.github.io/valkey-helm
   version: 0.9.2
-digest: sha256:c27b28990e23c8d06b940a61e61f62903d528ea5014ac05de970a95c480db694
-generated: "2026-01-09T21:09:41.894491862Z"
+- name: community-operator
+  repository: https://mongodb.github.io/helm-charts
+  version: 0.10.0
+digest: sha256:19614b8e1db596f9d5dff107ed849f2d71828ff393804f31f1f5966be978d192
+generated: "2026-01-09T21:39:43.215928807Z"

--- a/charts/courselit/Chart.lock
+++ b/charts/courselit/Chart.lock
@@ -4,6 +4,9 @@ dependencies:
   version: 0.9.2
 - name: community-operator
   repository: https://mongodb.github.io/helm-charts
-  version: 0.10.0
-digest: sha256:19614b8e1db596f9d5dff107ed849f2d71828ff393804f31f1f5966be978d192
-generated: "2026-01-09T21:39:43.215928807Z"
+  version: 0.13.0
+- name: community-operator
+  repository: https://mongodb.github.io/helm-charts
+  version: 0.13.0
+digest: sha256:be12c754e12d6fc898c469c7ba7136575bf973a80ac0e6ec2bfa5dbfe779692c
+generated: "2026-02-13T06:53:13.770954Z"

--- a/charts/courselit/Chart.lock
+++ b/charts/courselit/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: valkey
+  repository: https://valkey-io.github.io/valkey-helm
+  version: 0.9.2
+digest: sha256:c27b28990e23c8d06b940a61e61f62903d528ea5014ac05de970a95c480db694
+generated: "2026-01-09T21:09:41.894491862Z"

--- a/charts/courselit/Chart.yaml
+++ b/charts/courselit/Chart.yaml
@@ -24,3 +24,10 @@ dependencies:
     condition: queue.enabled,valkey.enabled
     tags:
       - queue
+  - name: community-operator
+    version: "0.10.0"
+    repository: "https://mongodb.github.io/helm-charts"
+    condition: mongodb.operator.enabled
+    tags:
+      - mongodb
+      - operator

--- a/charts/courselit/Chart.yaml
+++ b/charts/courselit/Chart.yaml
@@ -14,7 +14,7 @@ sources:
   - https://github.com/codelitdev/courselit
 maintainers:
   - name: CourseLIT Team
-    url: https://courselit.app
+    email: hello@courselit.app
 dependencies:
   - name: valkey
     version: "0.9.2"

--- a/charts/courselit/Chart.yaml
+++ b/charts/courselit/Chart.yaml
@@ -15,6 +15,8 @@ sources:
 maintainers:
   - name: CourseLIT Team
     email: hello@courselit.app
+  - name: DevOps Consultants
+    email: rob.coward@devops-consultants.co.uk
 dependencies:
   - name: valkey
     version: "0.9.2"

--- a/charts/courselit/Chart.yaml
+++ b/charts/courselit/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: courselit
 description: A Helm chart for deploying CourseLIT Learning Management System on Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.8
 appVersion: "latest"
 keywords:
   - courselit
@@ -25,9 +25,17 @@ dependencies:
     tags:
       - queue
   - name: community-operator
-    version: "0.10.0"
+    version: "0.13.0"
     repository: "https://mongodb.github.io/helm-charts"
     condition: mongodb.operator.enabled
     tags:
       - mongodb
       - operator
+  - name: community-operator
+    alias: mongodb-rbac
+    version: "0.13.0"
+    repository: "https://mongodb.github.io/helm-charts"
+    condition: mongodb.enabled
+    tags:
+      - mongodb
+      - rbac

--- a/charts/courselit/Chart.yaml
+++ b/charts/courselit/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: courselit
+description: A Helm chart for deploying CourseLIT Learning Management System on Kubernetes
+type: application
+version: 0.1.0
+appVersion: "latest"
+keywords:
+  - courselit
+  - lms
+  - education
+  - learning
+home: https://courselit.app
+sources:
+  - https://github.com/codelitdev/courselit
+maintainers:
+  - name: CourseLIT Team
+    url: https://courselit.app
+dependencies:
+  - name: valkey
+    version: "0.9.2"
+    repository: "https://valkey-io.github.io/valkey-helm"
+    condition: queue.enabled,valkey.enabled
+    tags:
+      - queue

--- a/charts/courselit/README.md
+++ b/charts/courselit/README.md
@@ -1,0 +1,327 @@
+# CourseLIT Helm Chart
+
+A Helm chart for deploying [CourseLIT](https://courselit.app) Learning Management System on Kubernetes.
+
+## Overview
+
+This chart deploys a production-ready CourseLIT instance with support for:
+- Main CourseLIT application
+- MongoDB (via Community Operator or external)
+- Optional queue service with Valkey/Redis
+- Optional MediaLit file storage service with AWS S3 integration
+- Ingress or Gateway API for external access
+
+## Prerequisites
+
+### Required
+
+- Kubernetes 1.24+
+- Helm 3.8+
+- External Secrets Operator for secret management
+- MongoDB Community Operator (if using in-cluster MongoDB)
+- Ingress controller OR Gateway API implementation
+
+### Installation Commands
+
+```bash
+# External Secrets Operator
+helm repo add external-secrets https://charts.external-secrets.io
+helm install external-secrets external-secrets/external-secrets \
+  -n external-secrets-system --create-namespace
+
+# MongoDB Community Operator (if using in-cluster MongoDB)
+helm repo add mongodb https://mongodb.github.io/helm-charts
+helm install mongodb-operator mongodb/community-operator
+
+# Nginx Ingress Controller (recommended)
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm install ingress-nginx ingress-nginx/ingress-nginx
+
+# Cert-Manager (for TLS)
+helm repo add jetstack https://charts.jetstack.io
+helm install cert-manager jetstack/cert-manager \
+  --namespace cert-manager --create-namespace --set installCRDs=true
+```
+
+## Installation
+
+### 1. Add Helm repository
+
+```bash
+# If published to a Helm repository
+helm repo add courselit https://your-helm-repo.com
+helm repo update
+```
+
+### 2. Create secrets
+
+```bash
+# Create namespace
+kubectl create namespace courselit
+
+# Auth secret
+kubectl create secret generic courselit-auth -n courselit \
+  --from-literal=auth-secret=$(openssl rand -base64 32)
+
+# Email credentials
+kubectl create secret generic courselit-email -n courselit \
+  --from-literal=email-user=your-email@example.com \
+  --from-literal=email-pass=your-password \
+  --from-literal=email-host=smtp.example.com \
+  --from-literal=email-from=noreply@example.com
+
+# MongoDB password (if using in-cluster MongoDB)
+kubectl create secret generic courselit-mongodb -n courselit \
+  --from-literal=password=$(openssl rand -base64 32)
+```
+
+### 3. Create values file
+
+Create `values-production.yaml`:
+
+```yaml
+app:
+  config:
+    superAdminEmail: admin@example.com
+
+  smtp:
+    host: smtp-relay.example.com
+    port: 587
+    user: smtp-user
+    from: noreply@example.com
+
+  ingress:
+    enabled: true
+    hosts:
+      - host: courselit.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - secretName: courselit-tls
+        hosts:
+          - courselit.example.com
+
+mongodb:
+  enabled: true
+```
+
+### 4. Install the chart
+
+```bash
+# Update dependencies (for Valkey subchart)
+helm dependency update
+
+# Install
+helm install courselit ./courselit -n courselit -f values-production.yaml
+```
+
+## Configuration
+
+### Main Application
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `app.replicaCount` | Number of app replicas | `1` |
+| `app.image.repository` | App image repository | `codelit/courselit-app` |
+| `app.image.tag` | App image tag | `latest` |
+| `app.config.superAdminEmail` | Super admin email (required) | `""` |
+| `app.smtp.host` | SMTP server hostname | `""` |
+| `app.smtp.port` | SMTP server port | `587` |
+| `app.secrets.authSecretRef.name` | Secret containing AUTH_SECRET | `courselit-auth` |
+| `app.ingress.enabled` | Enable Ingress | `true` |
+| `app.ingress.className` | Ingress class name | `nginx` |
+| `app.gateway.enabled` | Enable Gateway API (mutually exclusive with Ingress) | `false` |
+
+### MongoDB
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `mongodb.enabled` | Deploy MongoDB via operator | `true` |
+| `mongodb.external.connectionString` | External MongoDB connection string | `""` |
+| `mongodb.version` | MongoDB version | `7.0.0` |
+| `mongodb.type` | Deployment type (ReplicaSet/Standalone) | `ReplicaSet` |
+| `mongodb.members` | Number of replica set members | `3` |
+| `mongodb.auth.existingSecret` | Secret containing MongoDB password | `courselit-mongodb` |
+| `mongodb.storage.size` | Storage size for each MongoDB instance | `10Gi` |
+
+### Queue Service
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `queue.enabled` | Enable queue service | `false` |
+| `queue.config.domain` | Domain for email links | `courselit.example.com` |
+| `redis.external.enabled` | Use external Redis | `false` |
+| `redis.external.host` | External Redis hostname | `""` |
+| `valkey.enabled` | Deploy Valkey subchart | `true` |
+
+### MediaLit Service
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `medialit.enabled` | Enable MediaLit service | `false` |
+| `medialit.config.s3.bucketName` | S3 bucket name (required when enabled) | `""` |
+| `medialit.config.s3.region` | S3 region (required when enabled) | `""` |
+| `medialit.config.cloudfront.enabled` | Enable CloudFront | `false` |
+| `medialit.serviceAccount.annotations` | IRSA annotation for AWS IAM role | `{}` |
+| `medialit.externalSecrets.enabled` | Use External Secrets Operator | `true` |
+
+## Usage Examples
+
+### Minimal Deployment
+
+```bash
+helm install courselit ./courselit -n courselit \
+  --set app.config.superAdminEmail=admin@example.com
+```
+
+### With Queue Service
+
+```bash
+helm install courselit ./courselit -n courselit \
+  --set app.config.superAdminEmail=admin@example.com \
+  --set queue.enabled=true \
+  --set queue.config.domain=courselit.example.com
+```
+
+### With External MongoDB
+
+```yaml
+mongodb:
+  enabled: false
+  external:
+    connectionString: "mongodb+srv://user:pass@cluster.mongodb.net/courselit?retryWrites=true&w=majority"
+```
+
+### With MediaLit and AWS IRSA
+
+```yaml
+medialit:
+  enabled: true
+  config:
+    s3:
+      bucketName: my-courselit-media
+      region: us-east-1
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: "arn:aws:iam::123456789012:role/courselit-medialit"
+  externalSecrets:
+    enabled: true
+    secretStore:
+      name: aws-secrets-manager
+      kind: ClusterSecretStore
+```
+
+### With Gateway API
+
+```yaml
+app:
+  ingress:
+    enabled: false
+  gateway:
+    enabled: true
+    gatewayClassName: "eg"  # Envoy Gateway
+    hostnames:
+      - courselit.example.com
+```
+
+## Post-Installation
+
+### 1. Verify Deployment
+
+```bash
+kubectl get pods -n courselit
+kubectl get svc -n courselit
+kubectl get ingress -n courselit
+```
+
+### 2. Access Application
+
+Via port-forward (testing):
+```bash
+kubectl port-forward -n courselit svc/courselit-app 8080:80
+```
+
+Via ingress (production):
+```
+https://courselit.example.com
+```
+
+### 3. Retrieve Admin Login
+
+Check logs for magic login link:
+```bash
+kubectl logs -n courselit -l app.kubernetes.io/component=app | grep -i "magic link"
+```
+
+### 4. Configure SSO (Optional)
+
+SSO/SAML must be configured via the web UI:
+1. Login as super admin
+2. Navigate to Settings → Miscellaneous → Login providers
+3. Configure your IdP settings
+
+See: https://courselit.app/docs/en/schools/sso
+
+## Upgrading
+
+```bash
+helm upgrade courselit ./courselit -n courselit -f values-production.yaml
+```
+
+### Enable Queue Service
+
+```bash
+helm upgrade courselit ./courselit -n courselit -f values-production.yaml \
+  --set queue.enabled=true
+```
+
+## Troubleshooting
+
+### Pods Not Starting
+
+Check MongoDB connectivity:
+```bash
+kubectl logs -n courselit <pod-name> -c wait-for-mongodb
+```
+
+### Email Not Working
+
+Verify SMTP configuration:
+```bash
+kubectl get cm -n courselit courselit-app -o yaml
+kubectl get secret -n courselit courselit-email -o yaml
+```
+
+### MediaLit S3 Access Issues
+
+Check IRSA annotation:
+```bash
+kubectl describe sa -n courselit courselit-medialit
+```
+
+Verify ExternalSecret:
+```bash
+kubectl get externalsecret -n courselit
+kubectl describe externalsecret -n courselit courselit-medialit-secrets
+```
+
+## Uninstallation
+
+```bash
+helm uninstall courselit -n courselit
+kubectl delete namespace courselit
+```
+
+**Note**: This will delete all data. Backup MongoDB before uninstalling.
+
+## Support
+
+- Documentation: https://courselit.app/docs
+- GitHub: https://github.com/codelitdev/courselit
+- Discord: https://discord.com/invite/GR4bQsN
+
+## License
+
+This Helm chart is provided under the MIT License.
+CourseLIT itself is licensed under its own terms - see the project repository for details.

--- a/charts/courselit/ci/default-values.yaml
+++ b/charts/courselit/ci/default-values.yaml
@@ -1,0 +1,64 @@
+# CI test values - enables MongoDB operator for kind cluster testing
+# This file is used by chart-testing in GitHub Actions workflow
+
+app:
+  config:
+    superAdminEmail: admin@example.com
+
+  # Disable ingress in CI - kind cluster doesn't have ingress controller
+  ingress:
+    enabled: false
+
+  # Gateway API also disabled for CI
+  gateway:
+    enabled: false
+
+  # Use secrets that will be created in CI
+  secrets:
+    authSecretRef:
+      name: courselit-auth
+      key: auth-secret
+    emailSecretRef:
+      name: courselit-email
+      userKey: email-user
+      passKey: email-pass
+      hostKey: email-host
+      fromKey: email-from
+
+mongodb:
+  # Deploy MongoDB in CI
+  enabled: true
+
+  # IMPORTANT: Deploy operator in CI environment
+  # This allows the chart to be tested in kind cluster without pre-installed operator
+  operator:
+    enabled: true
+
+  # Use Standalone for faster CI testing (instead of ReplicaSet)
+  type: Standalone
+  members: 1
+
+  auth:
+    rootUsername: root
+    existingSecret: courselit-mongodb
+    secretKey: password
+
+  # Reduce resources for CI
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "250m"
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
+
+  storage:
+    size: 5Gi  # Smaller for CI
+
+# Disable queue service in default CI test
+queue:
+  enabled: false
+
+# Disable MediaLit in default CI test
+medialit:
+  enabled: false

--- a/charts/courselit/templates/NOTES.txt
+++ b/charts/courselit/templates/NOTES.txt
@@ -1,0 +1,85 @@
+Thank you for installing {{ .Chart.Name }}!
+
+Your CourseLIT Learning Management System has been deployed to namespace: {{ .Release.Namespace }}
+
+1. Get the application URL:
+{{- if .Values.app.gateway.enabled }}
+  Gateway API HTTPRoute has been created. Access your application at:
+  {{- range .Values.app.gateway.hostnames }}
+  https://{{ . }}
+  {{- end }}
+
+{{- else if .Values.app.ingress.enabled }}
+  Ingress has been created. Access your application at:
+  {{- range .Values.app.ingress.hosts }}
+  {{- range .paths }}
+  https://{{ .host }}{{ .path }}
+  {{- end }}
+  {{- end }}
+
+  NOTE: It may take a few minutes for the TLS certificate to be issued.
+
+{{- else }}
+  Get the application URL by running:
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "courselit.name" . }},app.kubernetes.io/component=app" -o jsonpath="{.items[0].metadata.name}")
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:{{ .Values.app.port }}
+
+  Then visit http://127.0.0.1:8080 in your browser
+{{- end }}
+
+2. Check deployment status:
+  kubectl get pods -n {{ .Release.Namespace }} -l "app.kubernetes.io/instance={{ .Release.Name }}"
+
+{{- if .Values.mongodb.enabled }}
+
+3. MongoDB status:
+  kubectl get mongodbcommunity -n {{ .Release.Namespace }}
+
+  NOTE: It may take several minutes for the MongoDB replica set to initialize and elect a primary.
+{{- end }}
+
+4. Retrieve super admin login:
+  The super admin user ({{ .Values.app.config.superAdminEmail }}) will receive a magic login link via email.
+  If email is not configured, check the application logs:
+
+  kubectl logs -n {{ .Release.Namespace }} -l "app.kubernetes.io/component=app" --tail=50 | grep -i "magic link"
+
+{{- if not .Values.app.smtp.host }}
+
+  WARNING: SMTP configuration is not set. Email functionality will be disabled.
+  To enable emails, update the SMTP settings in your values file and upgrade the release.
+{{- end }}
+
+5. Optional components:
+{{- if not .Values.queue.enabled }}
+  - Queue service: Currently DISABLED. Enable with --set queue.enabled=true
+{{- else }}
+  - Queue service: ENABLED and processing background jobs
+    Status: kubectl get pods -n {{ .Release.Namespace }} -l "app.kubernetes.io/component=queue"
+{{- end }}
+
+{{- if not .Values.medialit.enabled }}
+  - MediaLit service: Currently DISABLED. Enable with --set medialit.enabled=true
+{{- else }}
+  - MediaLit service: ENABLED for file storage
+    Status: kubectl get pods -n {{ .Release.Namespace }} -l "app.kubernetes.io/component=medialit"
+{{- end }}
+
+6. Important configuration notes:
+  - SSO/SAML: Must be configured via the web UI after login (Settings → Miscellaneous → Login providers)
+  - Payment gateways: Configure via the web UI (Settings → Payment)
+  - Custom domain: Update DNS records to point to your ingress/gateway
+
+7. Secret management:
+  This chart uses External Secrets Operator for sensitive data.
+  Ensure all referenced secrets exist before deployment:
+  - {{ .Values.app.secrets.authSecretRef.name }} (AUTH_SECRET)
+  - {{ .Values.app.secrets.emailSecretRef.name }} (Email credentials)
+{{- if .Values.mongodb.enabled }}
+  - {{ .Values.mongodb.auth.existingSecret }} (MongoDB password)
+{{- end }}
+
+For more information, visit:
+- Documentation: https://courselit.app/docs
+- GitHub: https://github.com/codelitdev/courselit
+- Discord: https://discord.com/invite/GR4bQsN

--- a/charts/courselit/templates/_helpers.tpl
+++ b/charts/courselit/templates/_helpers.tpl
@@ -1,0 +1,218 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "courselit.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "courselit.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "courselit.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "courselit.labels" -}}
+helm.sh/chart: {{ include "courselit.chart" . }}
+{{ include "courselit.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "courselit.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "courselit.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+App component labels
+*/}}
+{{- define "courselit.app.labels" -}}
+{{ include "courselit.labels" . }}
+app.kubernetes.io/component: app
+{{- end }}
+
+{{/*
+App selector labels
+*/}}
+{{- define "courselit.app.selectorLabels" -}}
+{{ include "courselit.selectorLabels" . }}
+app.kubernetes.io/component: app
+{{- end }}
+
+{{/*
+Queue component labels
+*/}}
+{{- define "courselit.queue.labels" -}}
+{{ include "courselit.labels" . }}
+app.kubernetes.io/component: queue
+{{- end }}
+
+{{/*
+Queue selector labels
+*/}}
+{{- define "courselit.queue.selectorLabels" -}}
+{{ include "courselit.selectorLabels" . }}
+app.kubernetes.io/component: queue
+{{- end }}
+
+{{/*
+MediaLit component labels
+*/}}
+{{- define "courselit.medialit.labels" -}}
+{{ include "courselit.labels" . }}
+app.kubernetes.io/component: medialit
+{{- end }}
+
+{{/*
+MediaLit selector labels
+*/}}
+{{- define "courselit.medialit.selectorLabels" -}}
+{{ include "courselit.selectorLabels" . }}
+app.kubernetes.io/component: medialit
+{{- end }}
+
+{{/*
+App image
+*/}}
+{{- define "courselit.app.image" -}}
+{{- printf "%s:%s" .Values.app.image.repository (.Values.app.image.tag | default .Chart.AppVersion) }}
+{{- end }}
+
+{{/*
+Queue image
+*/}}
+{{- define "courselit.queue.image" -}}
+{{- printf "%s:%s" .Values.queue.image.repository (.Values.queue.image.tag | default .Chart.AppVersion) }}
+{{- end }}
+
+{{/*
+MediaLit image
+*/}}
+{{- define "courselit.medialit.image" -}}
+{{- printf "%s:%s" .Values.medialit.image.repository (.Values.medialit.image.tag | default .Chart.AppVersion) }}
+{{- end }}
+
+{{/*
+MediaLit ServiceAccount name
+*/}}
+{{- define "courselit.medialit.serviceAccountName" -}}
+{{- if .Values.medialit.serviceAccount.create }}
+{{- default (printf "%s-medialit" (include "courselit.fullname" .)) .Values.medialit.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.medialit.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+MongoDB connection string for app
+*/}}
+{{- define "courselit.mongodb.connectionString" -}}
+{{- if .Values.mongodb.enabled }}
+{{- $fullname := include "courselit.fullname" . }}
+{{- $mongoHost := printf "%s-mongodb-svc.%s.svc.cluster.local" $fullname .Release.Namespace }}
+{{- printf "mongodb://%s:PASSWORD@%s/courselit?authSource=admin" .Values.mongodb.auth.rootUsername $mongoHost }}
+{{- else }}
+{{- .Values.mongodb.external.connectionString }}
+{{- end }}
+{{- end }}
+
+{{/*
+MongoDB connection string for MediaLit
+*/}}
+{{- define "courselit.mongodb.medialitConnectionString" -}}
+{{- if .Values.mongodb.enabled }}
+{{- $fullname := include "courselit.fullname" . }}
+{{- $mongoHost := printf "%s-mongodb-svc.%s.svc.cluster.local" $fullname .Release.Namespace }}
+{{- printf "mongodb://%s:PASSWORD@%s/medialit?authSource=admin" .Values.mongodb.auth.rootUsername $mongoHost }}
+{{- else }}
+{{- .Values.mongodb.external.connectionString | replace "/courselit" "/medialit" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Redis host for queue service
+*/}}
+{{- define "courselit.redis.host" -}}
+{{- if .Values.redis.external.enabled }}
+{{- .Values.redis.external.host }}
+{{- else }}
+{{- printf "%s-valkey-master" .Release.Name }}
+{{- end }}
+{{- end }}
+
+{{/*
+MongoDB wait initContainer
+*/}}
+{{- define "courselit.mongodb.initContainer" -}}
+- name: wait-for-mongodb
+  image: busybox:1.36
+  command:
+    - sh
+    - -c
+    - |
+      echo "Waiting for MongoDB to be ready..."
+      {{- if .Values.mongodb.enabled }}
+      {{- $fullname := include "courselit.fullname" . }}
+      MONGO_HOST="{{ printf "%s-mongodb-svc.%s.svc.cluster.local" $fullname .Release.Namespace }}"
+      {{- else }}
+      {{- $parts := regexSplit "mongodb://([^@]+@)?([^/]+)" .Values.mongodb.external.connectionString -1 }}
+      {{- if gt (len $parts) 2 }}
+      MONGO_HOST="{{ index $parts 2 | regexFind "[^:/]+" }}"
+      {{- else }}
+      MONGO_HOST="localhost"
+      {{- end }}
+      {{- end }}
+      until nc -z -w2 $MONGO_HOST 27017; do
+        echo "MongoDB not ready yet. Retrying in 2 seconds..."
+        sleep 2
+      done
+      echo "MongoDB is ready!"
+{{- end }}
+
+{{/*
+Redis wait initContainer
+*/}}
+{{- define "courselit.redis.initContainer" -}}
+- name: wait-for-redis
+  image: busybox:1.36
+  command:
+    - sh
+    - -c
+    - |
+      echo "Waiting for Redis to be ready..."
+      REDIS_HOST="{{ include "courselit.redis.host" . }}"
+      REDIS_PORT="{{ .Values.redis.external.port | default 6379 }}"
+      until nc -z -w2 $REDIS_HOST $REDIS_PORT; do
+        echo "Redis not ready yet. Retrying in 2 seconds..."
+        sleep 2
+      done
+      echo "Redis is ready!"
+{{- end }}

--- a/charts/courselit/templates/app-configmap.yaml
+++ b/charts/courselit/templates/app-configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "courselit.fullname" . }}-app
+  labels:
+    {{- include "courselit.app.labels" . | nindent 4 }}
+data:
+  NODE_ENV: {{ .Values.app.config.nodeEnv | quote }}
+  PORT: {{ .Values.app.port | quote }}
+  {{- if .Values.app.smtp.host }}
+  SMTP_HOST: {{ .Values.app.smtp.host | quote }}
+  SMTP_PORT: {{ .Values.app.smtp.port | quote }}
+  SMTP_USER: {{ .Values.app.smtp.user | quote }}
+  SMTP_FROM: {{ .Values.app.smtp.from | quote }}
+  {{- end }}

--- a/charts/courselit/templates/app-deployment.yaml
+++ b/charts/courselit/templates/app-deployment.yaml
@@ -18,8 +18,6 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      initContainers:
-        {{- include "courselit.mongodb.initContainer" . | nindent 8 }}
       containers:
         - name: app
           image: {{ include "courselit.app.image" . }}
@@ -60,10 +58,9 @@ spec:
                   name: {{ .Values.app.secrets.emailSecretRef.name }}
                   key: {{ .Values.app.secrets.emailSecretRef.hostKey }}
             - name: EMAIL_FROM
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.app.secrets.emailSecretRef.name }}
-                  key: {{ .Values.app.secrets.emailSecretRef.fromKey }}
+              value: {{ .Values.app.smtp.from | quote }}
+            - name: EMAIL_PORT
+              value: "{{ .Values.app.smtp.port }}"
             {{- if .Values.app.secrets.recaptchaSecretRef.name }}
             - name: RECAPTCHA_SITE_KEY
               valueFrom:
@@ -77,11 +74,19 @@ spec:
                   key: {{ .Values.app.secrets.recaptchaSecretRef.secretKeyKey }}
             {{- end }}
             {{- if .Values.mongodb.enabled }}
+            {{- if .Values.mongodb.useOperator }}
+            - name: DB_CONNECTION_STRING
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "courselit.fullname" . }}-mongodb-admin-{{ .Values.mongodb.auth.rootUsername }}
+                  key: connectionString.standard
+            {{- else }}
             - name: DB_CONNECTION_STRING
               valueFrom:
                 secretKeyRef:
                   name: {{ include "courselit.fullname" . }}-mongodb-connection
                   key: connectionString
+            {{- end }}
             {{- else }}
             - name: DB_CONNECTION_STRING
               value: {{ .Values.mongodb.external.connectionString | quote }}
@@ -114,3 +119,7 @@ spec:
             failureThreshold: 3
           resources:
             {{- toYaml .Values.app.resources | nindent 12 }}
+      {{- with .Values.app.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/courselit/templates/app-deployment.yaml
+++ b/charts/courselit/templates/app-deployment.yaml
@@ -1,0 +1,116 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "courselit.fullname" . }}-app
+  labels:
+    {{- include "courselit.app.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.app.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "courselit.app.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "courselit.app.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      initContainers:
+        {{- include "courselit.mongodb.initContainer" . | nindent 8 }}
+      containers:
+        - name: app
+          image: {{ include "courselit.app.image" . }}
+          imagePullPolicy: {{ .Values.app.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.app.port }}
+              protocol: TCP
+          env:
+            - name: NODE_ENV
+              value: {{ .Values.app.config.nodeEnv | quote }}
+            - name: PORT
+              value: {{ .Values.app.port | quote }}
+            - name: SUPER_ADMIN_EMAIL
+              value: {{ .Values.app.config.superAdminEmail | quote }}
+            - name: AUTH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.app.secrets.authSecretRef.name }}
+                  key: {{ .Values.app.secrets.authSecretRef.key }}
+            - name: EMAIL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.app.secrets.emailSecretRef.name }}
+                  key: {{ .Values.app.secrets.emailSecretRef.userKey }}
+            - name: EMAIL_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.app.secrets.emailSecretRef.name }}
+                  key: {{ .Values.app.secrets.emailSecretRef.passKey }}
+            - name: EMAIL_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.app.secrets.emailSecretRef.name }}
+                  key: {{ .Values.app.secrets.emailSecretRef.hostKey }}
+            - name: EMAIL_FROM
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.app.secrets.emailSecretRef.name }}
+                  key: {{ .Values.app.secrets.emailSecretRef.fromKey }}
+            {{- if .Values.app.secrets.recaptchaSecretRef.name }}
+            - name: RECAPTCHA_SITE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.app.secrets.recaptchaSecretRef.name }}
+                  key: {{ .Values.app.secrets.recaptchaSecretRef.siteKeyKey }}
+            - name: RECAPTCHA_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.app.secrets.recaptchaSecretRef.name }}
+                  key: {{ .Values.app.secrets.recaptchaSecretRef.secretKeyKey }}
+            {{- end }}
+            {{- if .Values.mongodb.enabled }}
+            - name: DB_CONNECTION_STRING
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "courselit.fullname" . }}-mongodb-connection
+                  key: connectionString
+            {{- else }}
+            - name: DB_CONNECTION_STRING
+              value: {{ .Values.mongodb.external.connectionString | quote }}
+            {{- end }}
+            {{- if .Values.queue.enabled }}
+            - name: QUEUE_SERVER
+              value: "http://{{ include "courselit.fullname" . }}-queue"
+            {{- end }}
+            {{- if .Values.medialit.enabled }}
+            - name: MEDIALIT_SERVER
+              value: "http://{{ include "courselit.fullname" . }}-medialit"
+            - name: MEDIALIT_APIKEY
+              value: "medialit-api-key"
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+          resources:
+            {{- toYaml .Values.app.resources | nindent 12 }}

--- a/charts/courselit/templates/app-httproute.yaml
+++ b/charts/courselit/templates/app-httproute.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.app.gateway.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "courselit.fullname" . }}-http
+  labels:
+    {{- include "courselit.app.labels" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ .Values.app.gateway.gatewayClassName }}
+      kind: Gateway
+  hostnames:
+    {{- range .Values.app.gateway.hostnames }}
+    - {{ . | quote }}
+    {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ include "courselit.fullname" . }}-app
+          port: {{ .Values.app.service.port }}
+{{- end }}

--- a/charts/courselit/templates/app-ingress.yaml
+++ b/charts/courselit/templates/app-ingress.yaml
@@ -1,0 +1,41 @@
+{{- if and .Values.app.ingress.enabled (not .Values.app.gateway.enabled) }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "courselit.fullname" . }}
+  labels:
+    {{- include "courselit.app.labels" . | nindent 4 }}
+  {{- with .Values.app.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.app.ingress.className }}
+  ingressClassName: {{ .Values.app.ingress.className }}
+  {{- end }}
+  {{- if .Values.app.ingress.tls }}
+  tls:
+    {{- range .Values.app.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.app.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "courselit.fullname" $ }}-app
+                port:
+                  number: {{ $.Values.app.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/courselit/templates/app-service.yaml
+++ b/charts/courselit/templates/app-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "courselit.fullname" . }}-app
+  labels:
+    {{- include "courselit.app.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.app.service.type }}
+  ports:
+    - port: {{ .Values.app.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "courselit.app.selectorLabels" . | nindent 4 }}

--- a/charts/courselit/templates/extra-manifests.yaml
+++ b/charts/courselit/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/charts/courselit/templates/medialit/configmap.yaml
+++ b/charts/courselit/templates/medialit/configmap.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.medialit.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "courselit.fullname" . }}-medialit
+  labels:
+    {{- include "courselit.medialit.labels" . | nindent 4 }}
+data:
+  CLOUD_BUCKET_NAME: {{ .Values.medialit.config.s3.bucketName | quote }}
+  CLOUD_REGION: {{ .Values.medialit.config.s3.region | quote }}
+  {{- if .Values.medialit.config.s3.prefix }}
+  CLOUD_PREFIX: {{ .Values.medialit.config.s3.prefix | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/courselit/templates/medialit/deployment.yaml
+++ b/charts/courselit/templates/medialit/deployment.yaml
@@ -1,0 +1,108 @@
+{{- if .Values.medialit.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "courselit.fullname" . }}-medialit
+  labels:
+    {{- include "courselit.medialit.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.medialit.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "courselit.medialit.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "courselit.medialit.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "courselit.medialit.serviceAccountName" . }}
+      initContainers:
+        {{- include "courselit.mongodb.initContainer" . | nindent 8 }}
+      containers:
+        - name: medialit
+          image: {{ include "courselit.medialit.image" . }}
+          imagePullPolicy: {{ .Values.medialit.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          env:
+            - name: EMAIL
+              value: {{ .Values.app.config.superAdminEmail | quote }}
+            {{- if .Values.mongodb.enabled }}
+            - name: DB_CONNECTION_STRING
+              value: {{ include "courselit.mongodb.medialitConnectionString" . | quote }}
+            {{- else }}
+            - name: DB_CONNECTION_STRING
+              value: {{ .Values.mongodb.external.connectionString | replace "/courselit" "/medialit" | quote }}
+            {{- end }}
+            - name: CLOUD_BUCKET_NAME
+              value: {{ .Values.medialit.config.s3.bucketName | quote }}
+            - name: CLOUD_REGION
+              value: {{ .Values.medialit.config.s3.region | quote }}
+            {{- if .Values.medialit.config.s3.endpoint }}
+            - name: CLOUD_ENDPOINT
+              value: {{ .Values.medialit.config.s3.endpoint | quote }}
+            - name: S3_ENDPOINT
+              value: {{ .Values.medialit.config.s3.endpoint | quote }}
+            {{- end }}
+            {{- if .Values.medialit.config.s3.prefix }}
+            - name: CLOUD_PREFIX
+              value: {{ .Values.medialit.config.s3.prefix | quote }}
+            {{- end }}
+            - name: TEMP_FILE_DIR_FOR_UPLOADS
+              value: "/tmp"
+            {{- if .Values.medialit.config.enableTrustProxy }}
+            - name: ENABLE_TRUST_PROXY
+              value: "true"
+            {{- end }}
+            {{- if .Values.medialit.config.cloudfront.enabled }}
+            - name: USE_CLOUDFRONT
+              value: "true"
+            - name: CLOUDFRONT_ENDPOINT
+              value: {{ .Values.medialit.config.cloudfront.endpoint | quote }}
+            - name: CLOUDFRONT_KEY_PAIR_ID
+              value: {{ .Values.medialit.config.cloudfront.keyPairId | quote }}
+            - name: CDN_MAX_AGE
+              value: {{ .Values.medialit.config.cloudfront.maxAge | quote }}
+            - name: CLOUDFRONT_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "courselit.fullname" . }}-medialit-secrets
+                  key: cloudfront-private-key
+            {{- end }}
+            {{- if and .Values.medialit.externalSecrets.enabled .Values.medialit.externalSecrets.s3Credentials.enabled }}
+            - name: CLOUD_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "courselit.fullname" . }}-medialit-secrets
+                  key: aws-access-key-id
+            - name: CLOUD_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "courselit.fullname" . }}-medialit-secrets
+                  key: aws-secret-access-key
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.medialit.resources | nindent 12 }}
+{{- end }}

--- a/charts/courselit/templates/medialit/externalsecret.yaml
+++ b/charts/courselit/templates/medialit/externalsecret.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.medialit.enabled .Values.medialit.externalSecrets.enabled }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "courselit.fullname" . }}-medialit-secrets
+  labels:
+    {{- include "courselit.medialit.labels" . | nindent 4 }}
+spec:
+  secretStoreRef:
+    name: {{ .Values.medialit.externalSecrets.secretStore.name }}
+    kind: {{ .Values.medialit.externalSecrets.secretStore.kind }}
+  target:
+    name: {{ include "courselit.fullname" . }}-medialit-secrets
+    creationPolicy: Owner
+  data:
+    {{- if .Values.medialit.externalSecrets.s3Credentials.enabled }}
+    - secretKey: aws-access-key-id
+      remoteRef:
+        key: {{ .Values.medialit.externalSecrets.s3Credentials.keyRef }}
+    - secretKey: aws-secret-access-key
+      remoteRef:
+        key: {{ .Values.medialit.externalSecrets.s3Credentials.secretRef }}
+    {{- end }}
+    {{- if .Values.medialit.externalSecrets.cloudfrontPrivateKey.enabled }}
+    - secretKey: cloudfront-private-key
+      remoteRef:
+        key: {{ .Values.medialit.externalSecrets.cloudfrontPrivateKey.keyRef }}
+    {{- end }}
+{{- end }}

--- a/charts/courselit/templates/medialit/service.yaml
+++ b/charts/courselit/templates/medialit/service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.medialit.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "courselit.fullname" . }}-medialit
+  labels:
+    {{- include "courselit.medialit.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.medialit.service.type }}
+  ports:
+    - port: {{ .Values.medialit.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "courselit.medialit.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/courselit/templates/medialit/serviceaccount.yaml
+++ b/charts/courselit/templates/medialit/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.medialit.enabled .Values.medialit.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "courselit.medialit.serviceAccountName" . }}
+  labels:
+    {{- include "courselit.medialit.labels" . | nindent 4 }}
+  {{- with .Values.medialit.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/courselit/templates/mongodb-community.yaml
+++ b/charts/courselit/templates/mongodb-community.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.mongodb.enabled }}
+{{- if and .Values.mongodb.enabled .Values.mongodb.useOperator }}
 apiVersion: mongodbcommunity.mongodb.com/v1
 kind: MongoDBCommunity
 metadata:

--- a/charts/courselit/templates/mongodb-community.yaml
+++ b/charts/courselit/templates/mongodb-community.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.mongodb.enabled }}
+apiVersion: mongodbcommunity.mongodb.com/v1
+kind: MongoDBCommunity
+metadata:
+  name: {{ include "courselit.fullname" . }}-mongodb
+  labels:
+    {{- include "courselit.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mongodb
+spec:
+  members: {{ .Values.mongodb.members }}
+  type: {{ .Values.mongodb.type }}
+  version: {{ .Values.mongodb.version | quote }}
+  security:
+    authentication:
+      modes: ["SCRAM"]
+  users:
+    - name: {{ .Values.mongodb.auth.rootUsername }}
+      db: admin
+      passwordSecretRef:
+        name: {{ .Values.mongodb.auth.existingSecret }}
+        key: {{ .Values.mongodb.auth.secretKey }}
+      roles:
+        - name: root
+          db: admin
+      scramCredentialsSecretName: {{ include "courselit.fullname" . }}-mongodb-scram
+  statefulSet:
+    spec:
+      volumeClaimTemplates:
+        - metadata:
+            name: data-volume
+          spec:
+            {{- if .Values.mongodb.storage.storageClass }}
+            storageClassName: {{ .Values.mongodb.storage.storageClass }}
+            {{- end }}
+            accessModes: ["ReadWriteOnce"]
+            resources:
+              requests:
+                storage: {{ .Values.mongodb.storage.size }}
+      template:
+        spec:
+          containers:
+            - name: mongod
+              resources:
+                {{- toYaml .Values.mongodb.resources | nindent 16 }}
+            - name: mongodb-agent
+              resources:
+                requests:
+                  memory: "128Mi"
+                  cpu: "100m"
+                limits:
+                  memory: "256Mi"
+                  cpu: "200m"
+{{- end }}

--- a/charts/courselit/templates/mongodb-secret.yaml
+++ b/charts/courselit/templates/mongodb-secret.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.mongodb.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "courselit.fullname" . }}-mongodb-connection
+  labels:
+    {{- include "courselit.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mongodb
+type: Opaque
+stringData:
+  connectionString: {{ include "courselit.mongodb.connectionString" . | replace "PASSWORD" (printf "$(cat /run/secrets/%s/%s)" .Values.mongodb.auth.existingSecret .Values.mongodb.auth.secretKey) }}
+{{- end }}

--- a/charts/courselit/templates/mongodb-secret.yaml
+++ b/charts/courselit/templates/mongodb-secret.yaml
@@ -1,4 +1,15 @@
 {{- if .Values.mongodb.enabled }}
+{{- $mongoPassword := "" }}
+{{- if .Values.createTestSecrets }}
+{{- /* For CI/testing, use the known test password */}}
+{{- $mongoPassword = "test-mongodb-password" | urlquery }}
+{{- else }}
+{{- /* For production, try to lookup existing secret */}}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace .Values.mongodb.auth.existingSecret }}
+{{- if $existingSecret }}
+{{- $mongoPassword = $existingSecret.data.password | b64dec | urlquery }}
+{{- end }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,5 +19,5 @@ metadata:
     app.kubernetes.io/component: mongodb
 type: Opaque
 stringData:
-  connectionString: {{ include "courselit.mongodb.connectionString" . | replace "PASSWORD" (printf "$(cat /run/secrets/%s/%s)" .Values.mongodb.auth.existingSecret .Values.mongodb.auth.secretKey) }}
+  connectionString: {{ include "courselit.mongodb.connectionString" . | replace "PASSWORD" $mongoPassword }}
 {{- end }}

--- a/charts/courselit/templates/mongodb-statefulset.yaml
+++ b/charts/courselit/templates/mongodb-statefulset.yaml
@@ -1,0 +1,83 @@
+{{- if and .Values.mongodb.enabled (not .Values.mongodb.useOperator) }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "courselit.fullname" . }}-mongodb-svc
+  labels:
+    {{- include "courselit.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mongodb
+spec:
+  ports:
+    - port: 27017
+      targetPort: 27017
+      name: mongodb
+  clusterIP: None
+  selector:
+    {{- include "courselit.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: mongodb
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "courselit.fullname" . }}-mongodb
+  labels:
+    {{- include "courselit.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mongodb
+spec:
+  serviceName: {{ include "courselit.fullname" . }}-mongodb-svc
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "courselit.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: mongodb
+  template:
+    metadata:
+      labels:
+        {{- include "courselit.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: mongodb
+    spec:
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: mongodb
+          image: "{{ .Values.mongodb.simple.image.repository }}:{{ .Values.mongodb.simple.image.tag }}"
+          imagePullPolicy: {{ .Values.mongodb.simple.image.pullPolicy }}
+          ports:
+            - containerPort: 27017
+              name: mongodb
+          env:
+            - name: MONGO_INITDB_ROOT_USERNAME
+              value: {{ .Values.mongodb.auth.rootUsername | quote }}
+            - name: MONGO_INITDB_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.mongodb.auth.existingSecret }}
+                  key: {{ .Values.mongodb.auth.secretKey }}
+          {{- with .Values.mongodb.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /data/db
+      {{- if .Values.mongodb.storage.useEmptyDir }}
+      volumes:
+        - name: data
+          emptyDir: {}
+      {{- end }}
+  {{- if not .Values.mongodb.storage.useEmptyDir }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        {{- if .Values.mongodb.storage.storageClass }}
+        storageClassName: {{ .Values.mongodb.storage.storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.mongodb.storage.size }}
+  {{- end }}
+{{- end }}

--- a/charts/courselit/templates/queue/configmap.yaml
+++ b/charts/courselit/templates/queue/configmap.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.queue.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "courselit.fullname" . }}-queue
+  labels:
+    {{- include "courselit.queue.labels" . | nindent 4 }}
+data:
+  DOMAIN: {{ .Values.queue.config.domain | quote }}
+  PROTOCOL: {{ .Values.queue.config.protocol | quote }}
+{{- end }}

--- a/charts/courselit/templates/queue/deployment.yaml
+++ b/charts/courselit/templates/queue/deployment.yaml
@@ -1,0 +1,101 @@
+{{- if .Values.queue.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "courselit.fullname" . }}-queue
+  labels:
+    {{- include "courselit.queue.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.queue.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "courselit.queue.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "courselit.queue.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      initContainers:
+        {{- include "courselit.mongodb.initContainer" . | nindent 8 }}
+        {{- include "courselit.redis.initContainer" . | nindent 8 }}
+      containers:
+        - name: queue
+          image: {{ include "courselit.queue.image" . }}
+          imagePullPolicy: {{ .Values.queue.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          env:
+            - name: NODE_ENV
+              value: "production"
+            - name: PORT
+              value: "80"
+            - name: DOMAIN
+              value: {{ .Values.queue.config.domain | quote }}
+            - name: PROTOCOL
+              value: {{ .Values.queue.config.protocol | quote }}
+            - name: COURSELIT_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.queue.secrets.courselitJwtSecretRef.name }}
+                  key: {{ .Values.queue.secrets.courselitJwtSecretRef.key }}
+            - name: EMAIL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.app.secrets.emailSecretRef.name }}
+                  key: {{ .Values.app.secrets.emailSecretRef.userKey }}
+            - name: EMAIL_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.app.secrets.emailSecretRef.name }}
+                  key: {{ .Values.app.secrets.emailSecretRef.passKey }}
+            - name: EMAIL_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.app.secrets.emailSecretRef.name }}
+                  key: {{ .Values.app.secrets.emailSecretRef.hostKey }}
+            {{- if .Values.mongodb.enabled }}
+            - name: DB_CONNECTION_STRING
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "courselit.fullname" . }}-mongodb-connection
+                  key: connectionString
+            {{- else }}
+            - name: DB_CONNECTION_STRING
+              value: {{ .Values.mongodb.external.connectionString | quote }}
+            {{- end }}
+            - name: REDIS_HOST
+              value: {{ include "courselit.redis.host" . | quote }}
+            - name: REDIS_PORT
+              value: {{ .Values.redis.external.port | default 6379 | quote }}
+            {{- if and .Values.redis.external.enabled .Values.redis.external.passwordSecretRef.name }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.redis.external.passwordSecretRef.name }}
+                  key: {{ .Values.redis.external.passwordSecretRef.key }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.queue.resources | nindent 12 }}
+{{- end }}

--- a/charts/courselit/templates/queue/service.yaml
+++ b/charts/courselit/templates/queue/service.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.queue.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "courselit.fullname" . }}-queue
+  labels:
+    {{- include "courselit.queue.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.queue.service.type }}
+  ports:
+    - port: {{ .Values.queue.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "courselit.queue.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/courselit/values.yaml
+++ b/charts/courselit/values.yaml
@@ -9,8 +9,8 @@ app:
     tag: latest
     pullPolicy: IfNotPresent
 
-  # Application port
-  port: 80
+  # Application port (use 8080 for non-root, 80 requires root)
+  port: 8080
 
   config:
     nodeEnv: production
@@ -35,7 +35,6 @@ app:
       userKey: "email-user"
       passKey: "email-pass"
       hostKey: "email-host"
-      fromKey: "email-from"
 
     recaptchaSecretRef:
       name: ""  # Optional - reCAPTCHA configuration
@@ -49,6 +48,10 @@ app:
     limits:
       memory: "512Mi"
       cpu: "500m"
+
+  # Node selector - image only available for amd64 architecture
+  nodeSelector:
+    kubernetes.io/arch: amd64
 
   # Kubernetes service configuration
   service:
@@ -94,20 +97,35 @@ mongodb:
   # Set to false to use external MongoDB (e.g., Atlas, DocumentDB)
   enabled: true
 
-  # MongoDB Community Operator deployment
+  # MongoDB deployment mode:
+  # - useOperator: false (default) - Deploy simple MongoDB StatefulSet (like docker-compose)
+  #   Best for: Development, testing, small deployments
+  # - useOperator: true - Use MongoDB Community Operator for production-grade deployment
+  #   Best for: Production, high-availability, replica sets
+  #   Requires: MongoDB Community Operator installed in cluster
+  useOperator: false
+
+  # MongoDB Community Operator deployment (when useOperator=true)
   operator:
     # Deploy operator as subchart dependency (default: false)
-    # Set to true for CI/CD testing or first-time installations
-    # In production, operator is typically installed cluster-wide
-    enabled: true
+    # NOTE: This can cause CRD timing issues. It's recommended to install
+    # the operator separately: helm install mongodb-operator mongodb/community-operator
+    enabled: false
 
   # External MongoDB connection (used when enabled=false)
   external:
     connectionString: ""  # Full connection string for external MongoDB
 
-  # In-cluster MongoDB (used when enabled=true)
+  # Simple MongoDB deployment (used when enabled=true and useOperator=false)
+  simple:
+    image:
+      repository: mongo
+      tag: "8.2"
+      pullPolicy: IfNotPresent
+
+  # Operator-based MongoDB (used when enabled=true and useOperator=true)
   # Requires MongoDB Community Operator
-  version: "7.0.0"
+  version: "8.2"
   type: ReplicaSet  # or "Standalone"
   members: 3
 
@@ -118,6 +136,8 @@ mongodb:
     secretKey: "password"
 
   storage:
+    # Use emptyDir instead of PVC (useful for CI/testing, data is not persisted)
+    useEmptyDir: false
     storageClass: ""  # Use cluster default if not specified
     size: 10Gi
 
@@ -128,6 +148,13 @@ mongodb:
     limits:
       memory: "1Gi"
       cpu: "1000m"
+
+mongodb-rbac:
+  operator:
+    enabled: false
+  databaseRoles:
+    create: true
+    namespace: "courselit"
 
 # Queue service (optional)
 queue:
@@ -237,7 +264,7 @@ medialit:
   serviceAccount:
     create: true
     annotations: {}
-      # eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME
+    # eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME
     name: ""
 
   resources:
@@ -271,3 +298,25 @@ securityContext:
     drop:
       - ALL
   readOnlyRootFilesystem: false
+
+# Extra Kubernetes manifests to deploy
+# This allows you to deploy additional resources like ExternalSecrets, ConfigMaps, etc.
+# Example:
+# extraManifests:
+#   - apiVersion: external-secrets.io/v1beta1
+#     kind: ExternalSecret
+#     metadata:
+#       name: "{{ include \"courselit.fullname\" . }}-aws-secret"
+#     spec:
+#       refreshInterval: 1h
+#       secretStoreRef:
+#         name: aws-secretsmanager
+#         kind: ClusterSecretStore
+#       target:
+#         name: courselit-auth
+#         creationPolicy: Owner
+#       data:
+#         - secretKey: auth-secret
+#           remoteRef:
+#             key: courselit/auth-secret
+extraManifests: []

--- a/charts/courselit/values.yaml
+++ b/charts/courselit/values.yaml
@@ -94,6 +94,13 @@ mongodb:
   # Set to false to use external MongoDB (e.g., Atlas, DocumentDB)
   enabled: true
 
+  # MongoDB Community Operator deployment
+  operator:
+    # Deploy operator as subchart dependency (default: false)
+    # Set to true for CI/CD testing or first-time installations
+    # In production, operator is typically installed cluster-wide
+    enabled: false
+
   # External MongoDB connection (used when enabled=false)
   external:
     connectionString: ""  # Full connection string for external MongoDB

--- a/charts/courselit/values.yaml
+++ b/charts/courselit/values.yaml
@@ -1,0 +1,266 @@
+# Default values for courselit Helm chart
+
+# Main CourseLIT application
+app:
+  replicaCount: 1
+
+  image:
+    repository: codelit/courselit-app
+    tag: latest
+    pullPolicy: IfNotPresent
+
+  # Application port
+  port: 80
+
+  config:
+    nodeEnv: production
+    # REQUIRED: Super admin email address
+    superAdminEmail: ""
+
+  # SMTP relay configuration
+  smtp:
+    host: ""      # SMTP relay host (e.g., smtp-relay.example.com)
+    port: 587     # SMTP port
+    user: ""      # SMTP username
+    from: ""      # From email address
+
+  # Secrets referenced via External Secrets Operator
+  secrets:
+    authSecretRef:
+      name: "courselit-auth"
+      key: "auth-secret"
+
+    emailSecretRef:
+      name: "courselit-email"
+      userKey: "email-user"
+      passKey: "email-pass"
+      hostKey: "email-host"
+      fromKey: "email-from"
+
+    recaptchaSecretRef:
+      name: ""  # Optional - reCAPTCHA configuration
+      siteKeyKey: "site-key"
+      secretKeyKey: "secret-key"
+
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "250m"
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
+
+  # Kubernetes service configuration
+  service:
+    type: ClusterIP
+    port: 80
+
+  # Ingress configuration (traditional)
+  ingress:
+    enabled: true
+    className: "nginx"  # Can be changed to traefik, haproxy, alb, etc.
+    annotations:
+      cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    hosts:
+      - host: courselit.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - secretName: courselit-tls
+        hosts:
+          - courselit.example.com
+
+  # Gateway API configuration (alternative to Ingress)
+  gateway:
+    enabled: false
+    gatewayClassName: "eg"  # e.g., "eg" for Envoy Gateway
+    listeners:
+      - name: http
+        protocol: HTTP
+        port: 80
+      - name: https
+        protocol: HTTPS
+        port: 443
+    hostnames:
+      - courselit.example.com
+    tls:
+      certificateRefs:
+        - name: courselit-tls
+          kind: Secret
+
+# MongoDB configuration
+mongodb:
+  # Set to false to use external MongoDB (e.g., Atlas, DocumentDB)
+  enabled: true
+
+  # External MongoDB connection (used when enabled=false)
+  external:
+    connectionString: ""  # Full connection string for external MongoDB
+
+  # In-cluster MongoDB (used when enabled=true)
+  # Requires MongoDB Community Operator
+  version: "7.0.0"
+  type: ReplicaSet  # or "Standalone"
+  members: 3
+
+  auth:
+    rootUsername: root
+    # Reference to existing secret containing MongoDB password
+    existingSecret: "courselit-mongodb"
+    secretKey: "password"
+
+  storage:
+    storageClass: ""  # Use cluster default if not specified
+    size: 10Gi
+
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "500m"
+    limits:
+      memory: "1Gi"
+      cpu: "1000m"
+
+# Queue service (optional)
+queue:
+  enabled: false
+
+  replicaCount: 1
+
+  image:
+    repository: codelit/courselit-queue
+    tag: latest
+    pullPolicy: IfNotPresent
+
+  config:
+    domain: "courselit.example.com"
+    protocol: "https"
+
+  secrets:
+    # Use External Secrets Operator
+    # Should reference same secret as app's authSecret
+    courselitJwtSecretRef:
+      name: "courselit-auth"
+      key: "auth-secret"
+
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "250m"
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
+
+  service:
+    type: ClusterIP
+    port: 80
+
+# Redis/Valkey configuration for queue service
+redis:
+  # External Redis/Valkey instance
+  external:
+    enabled: false
+    host: ""  # External Redis host
+    port: 6379
+    password: ""  # Optional password (leave empty if not using auth)
+    # Reference to secret containing Redis password
+    passwordSecretRef:
+      name: ""
+      key: "redis-password"
+
+# Valkey (Redis replacement) - subchart for in-cluster deployment
+# Only used when queue.enabled=true and valkey.enabled=true
+valkey:
+  enabled: true
+
+  # Valkey subchart values
+  master:
+    persistence:
+      enabled: true
+      size: 8Gi
+  auth:
+    enabled: false  # Can be enabled for security
+
+# MediaLit service (optional)
+medialit:
+  enabled: false
+
+  replicaCount: 1
+
+  image:
+    repository: codelit/medialit
+    tag: latest
+    pullPolicy: IfNotPresent
+
+  config:
+    s3:
+      bucketName: ""  # REQUIRED when enabled
+      region: ""      # REQUIRED when enabled
+      endpoint: ""    # Optional - defaults to AWS S3
+      prefix: ""      # Optional - S3 key prefix
+
+    cloudfront:
+      enabled: false
+      endpoint: ""
+      keyPairId: ""
+      maxAge: "3600"
+
+    enableTrustProxy: false
+
+  # External Secrets for MediaLit
+  externalSecrets:
+    enabled: true
+    secretStore:
+      name: ""  # Name of SecretStore or ClusterSecretStore
+      kind: "SecretStore"  # or "ClusterSecretStore"
+
+    # S3 credentials (if not using IRSA)
+    s3Credentials:
+      enabled: false  # Set to true if not using IRSA
+      keyRef: ""      # Path to AWS_ACCESS_KEY_ID in secret store
+      secretRef: ""   # Path to AWS_SECRET_ACCESS_KEY in secret store
+
+    # CloudFront private key
+    cloudfrontPrivateKey:
+      enabled: false  # Set to true if CloudFront is enabled
+      keyRef: ""      # Path to CloudFront private key in secret store
+
+  # ServiceAccount for IRSA (AWS IAM Role for Service Accounts)
+  serviceAccount:
+    create: true
+    annotations: {}
+      # eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME
+    name: ""
+
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "250m"
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
+
+  service:
+    type: ClusterIP
+    port: 80
+
+# Global settings
+nameOverride: ""
+fullnameOverride: ""
+
+# Common labels applied to all resources
+commonLabels: {}
+
+# Pod security context
+podSecurityContext:
+  fsGroup: 1000
+
+# Container security context
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: false

--- a/charts/courselit/values.yaml
+++ b/charts/courselit/values.yaml
@@ -99,7 +99,7 @@ mongodb:
     # Deploy operator as subchart dependency (default: false)
     # Set to true for CI/CD testing or first-time installations
     # In production, operator is typically installed cluster-wide
-    enabled: false
+    enabled: true
 
   # External MongoDB connection (used when enabled=false)
   external:

--- a/ct.yaml
+++ b/ct.yaml
@@ -14,6 +14,7 @@ chart-dirs:
 # Chart repositories for dependencies
 chart-repos:
   - valkey=https://valkey-io.github.io/valkey-helm
+  - mongodb=https://mongodb.github.io/helm-charts
 
 # Helm extra arguments
 helm-extra-args: --timeout 600s

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,19 @@
+# Configuration for chart-testing
+# See: https://github.com/helm/chart-testing/blob/main/doc/ct_lint.md
+
+# Validate maintainers (set to false to skip validation)
+validate-maintainers: false
+
+# Target branch for detecting chart changes
+target-branch: main
+
+# Chart directories
+chart-dirs:
+  - charts
+
+# Chart repositories for dependencies
+chart-repos:
+  - valkey=https://valkey-io.github.io/valkey-helm
+
+# Helm extra arguments
+helm-extra-args: --timeout 600s


### PR DESCRIPTION
## Summary
- The `mongodb-rbac` subchart dependency was gated on `mongodb.useOperator`, meaning the operator Deployment and RBAC resources deployed even when `mongodb.enabled` was `false`
- Changed the dependency condition to `mongodb.enabled` so the operator is only deployed when MongoDB is actually needed
- Syncs branch with published chart v0.1.7 changes and bumps to v0.1.8

## Test plan
- [ ] `helm template` with `mongodb.enabled=false` should NOT render the operator Deployment
- [ ] `helm template` with `mongodb.enabled=true` and `mongodb.useOperator=true` should render the operator Deployment
- [ ] Deploy to prod and verify ArgoCD prunes the operator resources when `mongodb.enabled=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)