### PR TITLE
chore(kafka-backup-operator): sync chart v1.0.0

### DIFF
--- a/charts/kafka-backup-operator/Chart.yaml
+++ b/charts/kafka-backup-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kafka-backup-operator
 description: A Kubernetes operator for managing Kafka backup and restore operations
 type: application
-version: 0.2.6
-appVersion: "0.2.6"
+version: 1.0.0
+appVersion: "1.0.0"
 home: https://github.com/osodevops/kafka-backup-operator
 sources:
   - https://github.com/osodevops/kafka-backup-operator

--- a/charts/kafka-backup-operator/crds/all.yaml
+++ b/charts/kafka-backup-operator/crds/all.yaml
@@ -109,6 +109,18 @@ spec:
                 description: Compression level (1-22 for zstd)
                 format: int32
                 type: integer
+              consumerGroupSnapshot:
+                default: false
+                description: Snapshot consumer group offsets to storage after each backup cycle
+                type: boolean
+              continuous:
+                default: false
+                description: Run continuously instead of completing after one pass
+                type: boolean
+              includeOffsetHeaders:
+                default: true
+                description: Include original offset headers for three-phase restore support
+                type: boolean
               kafkaCluster:
                 description: Kafka cluster connection configuration
                 properties:
@@ -117,6 +129,37 @@ spec:
                     items:
                       type: string
                     type: array
+                  connection:
+                    description: Kafka TCP connection tuning
+                    nullable: true
+                    properties:
+                      connectionsPerBroker:
+                        default: 4
+                        description: Number of TCP connections to maintain per broker
+                        format: uint
+                        minimum: 0.0
+                        type: integer
+                      keepaliveIntervalSecs:
+                        default: 20
+                        description: Interval in seconds between keepalive probes
+                        format: uint64
+                        minimum: 0.0
+                        type: integer
+                      keepaliveTimeSecs:
+                        default: 60
+                        description: Time in seconds before the first keepalive probe
+                        format: uint64
+                        minimum: 0.0
+                        type: integer
+                      tcpKeepalive:
+                        default: true
+                        description: Enable TCP keepalive
+                        type: boolean
+                      tcpNodelay:
+                        default: true
+                        description: Enable TCP_NODELAY
+                        type: boolean
+                    type: object
                   saslSecret:
                     description: SASL configuration secret reference
                     nullable: true
@@ -203,6 +246,12 @@ spec:
                     minimum: 0.0
                     type: integer
                 type: object
+              pollIntervalMs:
+                default: 100
+                description: Poll interval for continuous mode in milliseconds
+                format: uint64
+                minimum: 0.0
+                type: integer
               rateLimiting:
                 description: Rate limiting configuration
                 nullable: true
@@ -230,6 +279,26 @@ spec:
                 description: Cron schedule for automated backups
                 nullable: true
                 type: string
+              segmentMaxBytes:
+                default: 134217728
+                description: Maximum segment size in bytes before rotating
+                format: uint64
+                minimum: 0.0
+                type: integer
+              segmentMaxIntervalMs:
+                default: 60000
+                description: Maximum segment age in milliseconds before rotating
+                format: uint64
+                minimum: 0.0
+                type: integer
+              sourceClusterId:
+                description: Source cluster identifier recorded in manifests and offset headers
+                nullable: true
+                type: string
+              stopAtCurrentOffsets:
+                default: false
+                description: 'Snapshot mode: stop once current high watermarks are backed up'
+                type: boolean
               storage:
                 description: Storage configuration
                 properties:
@@ -379,6 +448,10 @@ spec:
                     description: S3 storage configuration
                     nullable: true
                     properties:
+                      allowHttp:
+                        description: Allow HTTP (insecure) connections to the endpoint (useful for in-cluster MinIO)
+                        nullable: true
+                        type: boolean
                       bucket:
                         description: S3 bucket name
                         type: string
@@ -403,6 +476,10 @@ spec:
                         description: Custom endpoint (for MinIO, Ceph, etc.)
                         nullable: true
                         type: string
+                      pathStyle:
+                        description: Force path-style addressing (useful for some S3-compatible endpoints like MinIO)
+                        nullable: true
+                        type: boolean
                       prefix:
                         description: Path prefix within bucket
                         nullable: true
@@ -581,6 +658,10 @@ spec:
           spec:
             description: KafkaRestore resource specification
             properties:
+              autoConsumerGroups:
+                default: false
+                description: Load consumer groups from the backup consumer-groups snapshot
+                type: boolean
               backupRef:
                 description: Reference to backup to restore from
                 properties:
@@ -745,6 +826,10 @@ spec:
                         description: S3 storage configuration
                         nullable: true
                         properties:
+                          allowHttp:
+                            description: Allow HTTP (insecure) connections to the endpoint (useful for in-cluster MinIO)
+                            nullable: true
+                            type: boolean
                           bucket:
                             description: S3 bucket name
                             type: string
@@ -769,6 +854,10 @@ spec:
                             description: Custom endpoint (for MinIO, Ceph, etc.)
                             nullable: true
                             type: string
+                          pathStyle:
+                            description: Force path-style addressing (useful for some S3-compatible endpoints like MinIO)
+                            nullable: true
+                            type: boolean
                           prefix:
                             description: Path prefix within bucket
                             nullable: true
@@ -843,6 +932,37 @@ spec:
                     items:
                       type: string
                     type: array
+                  connection:
+                    description: Kafka TCP connection tuning
+                    nullable: true
+                    properties:
+                      connectionsPerBroker:
+                        default: 4
+                        description: Number of TCP connections to maintain per broker
+                        format: uint
+                        minimum: 0.0
+                        type: integer
+                      keepaliveIntervalSecs:
+                        default: 20
+                        description: Interval in seconds between keepalive probes
+                        format: uint64
+                        minimum: 0.0
+                        type: integer
+                      keepaliveTimeSecs:
+                        default: 60
+                        description: Time in seconds before the first keepalive probe
+                        format: uint64
+                        minimum: 0.0
+                        type: integer
+                      tcpKeepalive:
+                        default: true
+                        description: Enable TCP keepalive
+                        type: boolean
+                      tcpNodelay:
+                        default: true
+                        description: Enable TCP_NODELAY
+                        type: boolean
+                    type: object
                   saslSecret:
                     description: SASL configuration secret reference
                     nullable: true
@@ -946,6 +1066,26 @@ spec:
                     nullable: true
                     type: integer
                 type: object
+              produceAcks:
+                default: -1
+                description: Producer acknowledgement level (-1 = all, 1 = leader, 0 = none)
+                format: int16
+                type: integer
+              produceBatchSize:
+                default: 1000
+                description: Batch size for producing to the target cluster
+                format: uint
+                minimum: 0.0
+                type: integer
+              produceTimeoutMs:
+                default: 30000
+                description: Broker-side produce timeout in milliseconds
+                format: int32
+                type: integer
+              purgeTopics:
+                default: false
+                description: Purge target topics before restore using Kafka DeleteRecords
+                type: boolean
               rateLimiting:
                 description: Rate limiting configuration
                 nullable: true
@@ -968,6 +1108,24 @@ spec:
                     format: uint64
                     minimum: 0.0
                     type: integer
+                type: object
+              repartitioning:
+                additionalProperties:
+                  description: Per-topic repartitioning configuration
+                  properties:
+                    strategy:
+                      default: murmur2
+                      description: Repartitioning strategy (murmur2 or automatic)
+                      type: string
+                    targetPartitions:
+                      description: Number of partitions in the target topic
+                      format: int32
+                      type: integer
+                  required:
+                  - targetPartitions
+                  type: object
+                default: {}
+                description: Per-topic repartitioning, keyed by target topic name
                 type: object
               rollback:
                 description: Rollback safety configuration
@@ -1211,6 +1369,37 @@ spec:
                     items:
                       type: string
                     type: array
+                  connection:
+                    description: Kafka TCP connection tuning
+                    nullable: true
+                    properties:
+                      connectionsPerBroker:
+                        default: 4
+                        description: Number of TCP connections to maintain per broker
+                        format: uint
+                        minimum: 0.0
+                        type: integer
+                      keepaliveIntervalSecs:
+                        default: 20
+                        description: Interval in seconds between keepalive probes
+                        format: uint64
+                        minimum: 0.0
+                        type: integer
+                      keepaliveTimeSecs:
+                        default: 60
+                        description: Time in seconds before the first keepalive probe
+                        format: uint64
+                        minimum: 0.0
+                        type: integer
+                      tcpKeepalive:
+                        default: true
+                        description: Enable TCP keepalive
+                        type: boolean
+                      tcpNodelay:
+                        default: true
+                        description: Enable TCP_NODELAY
+                        type: boolean
+                    type: object
                   saslSecret:
                     description: SASL configuration secret reference
                     nullable: true
@@ -1492,6 +1681,37 @@ spec:
                     items:
                       type: string
                     type: array
+                  connection:
+                    description: Kafka TCP connection tuning
+                    nullable: true
+                    properties:
+                      connectionsPerBroker:
+                        default: 4
+                        description: Number of TCP connections to maintain per broker
+                        format: uint
+                        minimum: 0.0
+                        type: integer
+                      keepaliveIntervalSecs:
+                        default: 20
+                        description: Interval in seconds between keepalive probes
+                        format: uint64
+                        minimum: 0.0
+                        type: integer
+                      keepaliveTimeSecs:
+                        default: 60
+                        description: Time in seconds before the first keepalive probe
+                        format: uint64
+                        minimum: 0.0
+                        type: integer
+                      tcpKeepalive:
+                        default: true
+                        description: Enable TCP keepalive
+                        type: boolean
+                      tcpNodelay:
+                        default: true
+                        description: Enable TCP_NODELAY
+                        type: boolean
+                    type: object
                   saslSecret:
                     description: SASL configuration secret reference
                     nullable: true
@@ -1675,6 +1895,874 @@ spec:
         required:
         - spec
         title: KafkaOffsetRollback
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kafkabackupvalidations.kafka.oso.sh
+spec:
+  group: kafka.oso.sh
+  names:
+    categories: []
+    kind: KafkaBackupValidation
+    plural: kafkabackupvalidations
+    shortNames:
+    - kbv
+    singular: kafkabackupvalidation
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.validationResult
+      name: Result
+      type: string
+    - jsonPath: .status.checksCompleted
+      name: Checks
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for KafkaBackupValidationSpec via `CustomResource`
+        properties:
+          spec:
+            description: KafkaBackupValidation resource specification
+            properties:
+              backupRef:
+                description: Reference to the backup to validate
+                properties:
+                  backupId:
+                    description: Specific backup ID to validate
+                    nullable: true
+                    type: string
+                  name:
+                    description: KafkaBackup resource name
+                    type: string
+                  namespace:
+                    description: Namespace (defaults to same namespace)
+                    nullable: true
+                    type: string
+                  storage:
+                    description: Direct storage reference (alternative to KafkaBackup resource lookup)
+                    nullable: true
+                    properties:
+                      azure:
+                        description: Azure Blob storage configuration
+                        nullable: true
+                        properties:
+                          accountName:
+                            description: Storage account name
+                            type: string
+                          container:
+                            description: Container name
+                            type: string
+                          credentialsSecret:
+                            description: Credentials secret reference for account key authentication Optional when using Workload Identity or Service Principal
+                            nullable: true
+                            properties:
+                              accountKeyKey:
+                                default: AZURE_STORAGE_KEY
+                                description: Account key key in secret
+                                type: string
+                              name:
+                                description: Secret name
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          endpoint:
+                            description: Custom endpoint URL (for Azure Government, China, or private endpoints)
+                            nullable: true
+                            type: string
+                          prefix:
+                            description: Path prefix within container
+                            nullable: true
+                            type: string
+                          sasTokenSecret:
+                            description: SAS token secret reference for time-limited access
+                            nullable: true
+                            properties:
+                              name:
+                                description: Secret name
+                                type: string
+                              sasTokenKey:
+                                default: AZURE_SAS_TOKEN
+                                description: SAS token key in secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          servicePrincipalSecret:
+                            description: Service Principal credentials for CI/CD pipelines
+                            nullable: true
+                            properties:
+                              clientIdKey:
+                                default: AZURE_CLIENT_ID
+                                description: Client ID key in secret
+                                type: string
+                              clientSecretKey:
+                                default: AZURE_CLIENT_SECRET
+                                description: Client secret key in secret
+                                type: string
+                              name:
+                                description: Secret name
+                                type: string
+                              tenantIdKey:
+                                default: AZURE_TENANT_ID
+                                description: Tenant ID key in secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          useWorkloadIdentity:
+                            default: false
+                            description: Use Azure Workload Identity for authentication When true, the operator uses the pod's federated identity token to authenticate with Azure Blob Storage (requires AKS with Workload Identity enabled) This is auto-detected if AZURE_FEDERATED_TOKEN_FILE environment variable is present
+                            type: boolean
+                        required:
+                        - accountName
+                        - container
+                        type: object
+                      gcs:
+                        description: GCS storage configuration
+                        nullable: true
+                        properties:
+                          bucket:
+                            description: GCS bucket name
+                            type: string
+                          credentialsSecret:
+                            description: Credentials secret reference
+                            properties:
+                              name:
+                                description: Secret name
+                                type: string
+                              serviceAccountJsonKey:
+                                default: SERVICE_ACCOUNT_JSON
+                                description: Service account JSON key in secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          prefix:
+                            description: Path prefix within bucket
+                            nullable: true
+                            type: string
+                        required:
+                        - bucket
+                        - credentialsSecret
+                        type: object
+                      pvc:
+                        description: PVC storage configuration
+                        nullable: true
+                        properties:
+                          claimName:
+                            description: PVC claim name
+                            type: string
+                          create:
+                            description: Auto-create PVC if not exists
+                            nullable: true
+                            properties:
+                              accessModes:
+                                default:
+                                - ReadWriteOnce
+                                description: Access modes
+                                items:
+                                  type: string
+                                type: array
+                              enabled:
+                                default: false
+                                description: Enable auto-creation
+                                type: boolean
+                              size:
+                                default: 100Gi
+                                description: Storage size (e.g., "100Gi")
+                                type: string
+                              storageClassName:
+                                description: Storage class name
+                                nullable: true
+                                type: string
+                            type: object
+                          subPath:
+                            description: Sub-path within the PVC
+                            nullable: true
+                            type: string
+                        required:
+                        - claimName
+                        type: object
+                      s3:
+                        description: S3 storage configuration
+                        nullable: true
+                        properties:
+                          allowHttp:
+                            description: Allow HTTP (insecure) connections to the endpoint (useful for in-cluster MinIO)
+                            nullable: true
+                            type: boolean
+                          bucket:
+                            description: S3 bucket name
+                            type: string
+                          credentialsSecret:
+                            description: Credentials secret reference
+                            properties:
+                              accessKeyIdKey:
+                                default: AWS_ACCESS_KEY_ID
+                                description: Access key ID key in secret
+                                type: string
+                              name:
+                                description: Secret name
+                                type: string
+                              secretAccessKeyKey:
+                                default: AWS_SECRET_ACCESS_KEY
+                                description: Secret access key key in secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          endpoint:
+                            description: Custom endpoint (for MinIO, Ceph, etc.)
+                            nullable: true
+                            type: string
+                          pathStyle:
+                            description: Force path-style addressing (useful for some S3-compatible endpoints like MinIO)
+                            nullable: true
+                            type: boolean
+                          prefix:
+                            description: Path prefix within bucket
+                            nullable: true
+                            type: string
+                          region:
+                            description: AWS region
+                            type: string
+                        required:
+                        - bucket
+                        - credentialsSecret
+                        - region
+                        type: object
+                      storageType:
+                        default: pvc
+                        description: Storage type (pvc, s3, azure, gcs)
+                        type: string
+                    type: object
+                required:
+                - name
+                type: object
+              checks:
+                description: Validation checks to run
+                properties:
+                  consumerGroupOffsets:
+                    description: Consumer group offset check (verify consumer group positions are backed up)
+                    nullable: true
+                    properties:
+                      consumerGroups:
+                        description: Consumer groups to check (empty = all groups)
+                        items:
+                          type: string
+                        type: array
+                      enabled:
+                        default: true
+                        description: Enable this check
+                        type: boolean
+                    type: object
+                  customWebhooks:
+                    description: Custom webhook checks (call external validation endpoints)
+                    items:
+                      description: Custom webhook check specification
+                      properties:
+                        expectedStatusCode:
+                          default: 200
+                          description: Expected HTTP status code
+                          format: uint16
+                          minimum: 0.0
+                          type: integer
+                        name:
+                          description: Display name for this check
+                          type: string
+                        timeoutSecs:
+                          default: 120
+                          description: Timeout in seconds
+                          format: uint64
+                          minimum: 0.0
+                          type: integer
+                        url:
+                          description: URL to POST validation payload to
+                          type: string
+                      required:
+                      - name
+                      - url
+                      type: object
+                    type: array
+                  messageCount:
+                    description: Message count check (compare record counts against backup manifest)
+                    nullable: true
+                    properties:
+                      enabled:
+                        default: true
+                        description: Enable this check
+                        type: boolean
+                      failThreshold:
+                        description: Acceptable difference threshold (number of records)
+                        format: uint64
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
+                      topics:
+                        description: Topics to check (empty = all topics from backup)
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  offsetRange:
+                    description: Offset range check (verify backup covers expected offset ranges)
+                    nullable: true
+                    properties:
+                      enabled:
+                        default: true
+                        description: Enable this check
+                        type: boolean
+                    type: object
+                type: object
+              evidence:
+                description: Evidence report configuration
+                nullable: true
+                properties:
+                  formats:
+                    default:
+                    - json
+                    description: Output formats (json, pdf)
+                    items:
+                      type: string
+                    type: array
+                  retentionDays:
+                    default: 90
+                    description: Retention period in days
+                    format: uint32
+                    minimum: 0.0
+                    type: integer
+                  signing:
+                    description: Cryptographic signing configuration
+                    nullable: true
+                    properties:
+                      enabled:
+                        default: false
+                        description: Enable ECDSA-P256-SHA256 signing
+                        type: boolean
+                      keySecret:
+                        description: Secret containing the ECDSA private key (PEM-encoded)
+                        properties:
+                          name:
+                            description: Secret name
+                            type: string
+                          privateKeyKey:
+                            default: signing-key.pem
+                            description: Key within secret containing the private key PEM
+                            type: string
+                          publicKeyKey:
+                            default: signing-key-pub.pem
+                            description: Key within secret containing the public key PEM
+                            type: string
+                        required:
+                        - name
+                        type: object
+                    required:
+                    - keySecret
+                    type: object
+                  storage:
+                    description: Storage location for evidence reports
+                    nullable: true
+                    properties:
+                      azure:
+                        description: Azure Blob storage configuration
+                        nullable: true
+                        properties:
+                          accountName:
+                            description: Storage account name
+                            type: string
+                          container:
+                            description: Container name
+                            type: string
+                          credentialsSecret:
+                            description: Credentials secret reference for account key authentication Optional when using Workload Identity or Service Principal
+                            nullable: true
+                            properties:
+                              accountKeyKey:
+                                default: AZURE_STORAGE_KEY
+                                description: Account key key in secret
+                                type: string
+                              name:
+                                description: Secret name
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          endpoint:
+                            description: Custom endpoint URL (for Azure Government, China, or private endpoints)
+                            nullable: true
+                            type: string
+                          prefix:
+                            description: Path prefix within container
+                            nullable: true
+                            type: string
+                          sasTokenSecret:
+                            description: SAS token secret reference for time-limited access
+                            nullable: true
+                            properties:
+                              name:
+                                description: Secret name
+                                type: string
+                              sasTokenKey:
+                                default: AZURE_SAS_TOKEN
+                                description: SAS token key in secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          servicePrincipalSecret:
+                            description: Service Principal credentials for CI/CD pipelines
+                            nullable: true
+                            properties:
+                              clientIdKey:
+                                default: AZURE_CLIENT_ID
+                                description: Client ID key in secret
+                                type: string
+                              clientSecretKey:
+                                default: AZURE_CLIENT_SECRET
+                                description: Client secret key in secret
+                                type: string
+                              name:
+                                description: Secret name
+                                type: string
+                              tenantIdKey:
+                                default: AZURE_TENANT_ID
+                                description: Tenant ID key in secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          useWorkloadIdentity:
+                            default: false
+                            description: Use Azure Workload Identity for authentication When true, the operator uses the pod's federated identity token to authenticate with Azure Blob Storage (requires AKS with Workload Identity enabled) This is auto-detected if AZURE_FEDERATED_TOKEN_FILE environment variable is present
+                            type: boolean
+                        required:
+                        - accountName
+                        - container
+                        type: object
+                      gcs:
+                        description: GCS storage configuration
+                        nullable: true
+                        properties:
+                          bucket:
+                            description: GCS bucket name
+                            type: string
+                          credentialsSecret:
+                            description: Credentials secret reference
+                            properties:
+                              name:
+                                description: Secret name
+                                type: string
+                              serviceAccountJsonKey:
+                                default: SERVICE_ACCOUNT_JSON
+                                description: Service account JSON key in secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          prefix:
+                            description: Path prefix within bucket
+                            nullable: true
+                            type: string
+                        required:
+                        - bucket
+                        - credentialsSecret
+                        type: object
+                      pvc:
+                        description: PVC storage configuration
+                        nullable: true
+                        properties:
+                          claimName:
+                            description: PVC claim name
+                            type: string
+                          create:
+                            description: Auto-create PVC if not exists
+                            nullable: true
+                            properties:
+                              accessModes:
+                                default:
+                                - ReadWriteOnce
+                                description: Access modes
+                                items:
+                                  type: string
+                                type: array
+                              enabled:
+                                default: false
+                                description: Enable auto-creation
+                                type: boolean
+                              size:
+                                default: 100Gi
+                                description: Storage size (e.g., "100Gi")
+                                type: string
+                              storageClassName:
+                                description: Storage class name
+                                nullable: true
+                                type: string
+                            type: object
+                          subPath:
+                            description: Sub-path within the PVC
+                            nullable: true
+                            type: string
+                        required:
+                        - claimName
+                        type: object
+                      s3:
+                        description: S3 storage configuration
+                        nullable: true
+                        properties:
+                          allowHttp:
+                            description: Allow HTTP (insecure) connections to the endpoint (useful for in-cluster MinIO)
+                            nullable: true
+                            type: boolean
+                          bucket:
+                            description: S3 bucket name
+                            type: string
+                          credentialsSecret:
+                            description: Credentials secret reference
+                            properties:
+                              accessKeyIdKey:
+                                default: AWS_ACCESS_KEY_ID
+                                description: Access key ID key in secret
+                                type: string
+                              name:
+                                description: Secret name
+                                type: string
+                              secretAccessKeyKey:
+                                default: AWS_SECRET_ACCESS_KEY
+                                description: Secret access key key in secret
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          endpoint:
+                            description: Custom endpoint (for MinIO, Ceph, etc.)
+                            nullable: true
+                            type: string
+                          pathStyle:
+                            description: Force path-style addressing (useful for some S3-compatible endpoints like MinIO)
+                            nullable: true
+                            type: boolean
+                          prefix:
+                            description: Path prefix within bucket
+                            nullable: true
+                            type: string
+                          region:
+                            description: AWS region
+                            type: string
+                        required:
+                        - bucket
+                        - credentialsSecret
+                        - region
+                        type: object
+                      storageType:
+                        default: pvc
+                        description: Storage type (pvc, s3, azure, gcs)
+                        type: string
+                    type: object
+                type: object
+              kafkaCluster:
+                description: Target Kafka cluster (required for consumer group offset checks)
+                nullable: true
+                properties:
+                  bootstrapServers:
+                    description: Bootstrap servers
+                    items:
+                      type: string
+                    type: array
+                  connection:
+                    description: Kafka TCP connection tuning
+                    nullable: true
+                    properties:
+                      connectionsPerBroker:
+                        default: 4
+                        description: Number of TCP connections to maintain per broker
+                        format: uint
+                        minimum: 0.0
+                        type: integer
+                      keepaliveIntervalSecs:
+                        default: 20
+                        description: Interval in seconds between keepalive probes
+                        format: uint64
+                        minimum: 0.0
+                        type: integer
+                      keepaliveTimeSecs:
+                        default: 60
+                        description: Time in seconds before the first keepalive probe
+                        format: uint64
+                        minimum: 0.0
+                        type: integer
+                      tcpKeepalive:
+                        default: true
+                        description: Enable TCP keepalive
+                        type: boolean
+                      tcpNodelay:
+                        default: true
+                        description: Enable TCP_NODELAY
+                        type: boolean
+                    type: object
+                  saslSecret:
+                    description: SASL configuration secret reference
+                    nullable: true
+                    properties:
+                      mechanism:
+                        description: SASL mechanism (PLAIN, SCRAM-SHA-256, SCRAM-SHA-512)
+                        type: string
+                      name:
+                        description: Secret name
+                        type: string
+                      passwordKey:
+                        default: password
+                        description: Password key in secret
+                        type: string
+                      usernameKey:
+                        default: username
+                        description: Username key in secret
+                        type: string
+                    required:
+                    - mechanism
+                    - name
+                    type: object
+                  securityProtocol:
+                    default: PLAINTEXT
+                    description: Security protocol (PLAINTEXT, SSL, SASL_PLAINTEXT, SASL_SSL)
+                    type: string
+                  tlsSecret:
+                    description: TLS configuration secret reference
+                    nullable: true
+                    properties:
+                      caKey:
+                        default: ca.crt
+                        description: CA certificate key in secret
+                        type: string
+                      certKey:
+                        description: Client certificate key in secret
+                        nullable: true
+                        type: string
+                      keyKey:
+                        description: Client key key in secret
+                        nullable: true
+                        type: string
+                      name:
+                        description: Secret name
+                        type: string
+                    required:
+                    - name
+                    type: object
+                required:
+                - bootstrapServers
+                type: object
+              notifications:
+                description: Notification channels
+                nullable: true
+                properties:
+                  pagerduty:
+                    description: PagerDuty notification
+                    nullable: true
+                    properties:
+                      routingKeySecret:
+                        description: Secret containing the integration/routing key
+                        properties:
+                          key:
+                            description: Key within the secret
+                            type: string
+                          name:
+                            description: Secret name
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      severity:
+                        default: critical
+                        description: Alert severity (critical, error, warning, info)
+                        type: string
+                    required:
+                    - routingKeySecret
+                    type: object
+                  slack:
+                    description: Slack notification
+                    nullable: true
+                    properties:
+                      webhookSecret:
+                        description: Secret containing the webhook URL
+                        properties:
+                          key:
+                            description: Key within the secret
+                            type: string
+                          name:
+                            description: Secret name
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                    required:
+                    - webhookSecret
+                    type: object
+                type: object
+              schedule:
+                description: Cron schedule for recurring validation
+                nullable: true
+                type: string
+              suspend:
+                default: false
+                description: Suspend validations
+                type: boolean
+            required:
+            - backupRef
+            - checks
+            type: object
+          status:
+            description: KafkaBackupValidation status
+            nullable: true
+            properties:
+              checkResults:
+                description: Per-check results
+                items:
+                  description: Per-check result in status
+                  properties:
+                    checkName:
+                      description: Check name
+                      type: string
+                    durationMs:
+                      description: Duration in milliseconds
+                      format: uint64
+                      minimum: 0.0
+                      nullable: true
+                      type: integer
+                    message:
+                      description: Human-readable detail
+                      nullable: true
+                      type: string
+                    outcome:
+                      description: Outcome (Passed, Failed, Skipped, Warning)
+                      type: string
+                  required:
+                  - checkName
+                  - outcome
+                  type: object
+                type: array
+              checksCompleted:
+                description: Number of checks completed
+                format: uint32
+                minimum: 0.0
+                nullable: true
+                type: integer
+              checksFailed:
+                description: Number of checks failed
+                format: uint32
+                minimum: 0.0
+                nullable: true
+                type: integer
+              checksPassed:
+                description: Number of checks passed
+                format: uint32
+                minimum: 0.0
+                nullable: true
+                type: integer
+              checksTotal:
+                description: Total number of checks configured
+                format: uint32
+                minimum: 0.0
+                nullable: true
+                type: integer
+              checksWarned:
+                description: Number of checks warned
+                format: uint32
+                minimum: 0.0
+                nullable: true
+                type: integer
+              completionTime:
+                description: Validation completion time
+                format: date-time
+                nullable: true
+                type: string
+              conditions:
+                description: Status conditions
+                items:
+                  description: Status condition
+                  properties:
+                    lastTransitionTime:
+                      description: Last transition time
+                      format: date-time
+                      type: string
+                    message:
+                      description: Human-readable message
+                      nullable: true
+                      type: string
+                    reason:
+                      description: Reason for the condition
+                      nullable: true
+                      type: string
+                    status:
+                      description: Status (True, False, Unknown)
+                      type: string
+                    type:
+                      description: Condition type
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              evidenceReportPath:
+                description: Path to evidence report in storage
+                nullable: true
+                type: string
+              evidenceReportSigned:
+                description: Whether the evidence report is cryptographically signed
+                nullable: true
+                type: boolean
+              lastValidationTime:
+                description: Last successful validation time
+                format: date-time
+                nullable: true
+                type: string
+              message:
+                description: Human-readable message
+                nullable: true
+                type: string
+              nextScheduledValidation:
+                description: Next scheduled validation time
+                format: date-time
+                nullable: true
+                type: string
+              observedGeneration:
+                description: Observed generation
+                format: int64
+                nullable: true
+                type: integer
+              phase:
+                description: Current phase (Pending, Running, Completed, Failed)
+                nullable: true
+                type: string
+              startTime:
+                description: Validation start time
+                format: date-time
+                nullable: true
+                type: string
+              validationResult:
+                description: Overall validation result (Pass, Fail, Warn)
+                nullable: true
+                type: string
+            type: object
+        required:
+        - spec
+        title: KafkaBackupValidation
         type: object
     served: true
     storage: true

--- a/charts/kafka-backup-operator/templates/clusterrole.yaml
+++ b/charts/kafka-backup-operator/templates/clusterrole.yaml
@@ -131,6 +131,31 @@ rules:
     verbs:
       - update
 
+  # Custom resources - KafkaBackupValidation
+  - apiGroups: ["kafka.oso.sh"]
+    resources:
+      - kafkabackupvalidations
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups: ["kafka.oso.sh"]
+    resources:
+      - kafkabackupvalidations/status
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups: ["kafka.oso.sh"]
+    resources:
+      - kafkabackupvalidations/finalizers
+    verbs:
+      - update
+
   {{- if .Values.leaderElection.enabled }}
   # Coordination for leader election
   - apiGroups: ["coordination.k8s.io"]

--- a/charts/kafka-backup-operator/templates/deployment.yaml
+++ b/charts/kafka-backup-operator/templates/deployment.yaml
@@ -55,6 +55,9 @@ spec:
             - name: LEADER_ELECTION_RETRY_PERIOD
               value: {{ .Values.leaderElection.retryPeriod | quote }}
             {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           livenessProbe:
@@ -78,9 +81,15 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
       volumes:
         - name: tmp
           emptyDir: {}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       terminationGracePeriodSeconds: 30
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/kafka-backup-operator/values.yaml
+++ b/charts/kafka-backup-operator/values.yaml
@@ -73,6 +73,15 @@ tolerations: []
 
 affinity: {}
 
+# Extra pod volumes to mount into the operator pod
+extraVolumes: []
+
+# Extra volume mounts for the operator container
+extraVolumeMounts: []
+
+# Extra environment variables for the operator container
+extraEnv: []
+
 # Logging configuration
 logging:
   level: "info,kafka_backup_operator=debug"


### PR DESCRIPTION
## Summary

Automated sync of `kafka-backup-operator` Helm chart.

**Chart Version:** `1.0.0`
**App Version:** `1.0.0`
**Source Commit:** [`4ddccc9cf6e4aa0e9e2b9b04cf85a3c5d88b18da`](https://github.com/osodevops/kafka-backup-operator/commit/4ddccc9cf6e4aa0e9e2b9b04cf85a3c5d88b18da)

---
*Auto-generated by [Helm Chart Sync Workflow](https://github.com/osodevops/kafka-backup-operator/actions/runs/24344566004)*