### PR TITLE
ci: add bitnami Helm repo to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,6 +28,7 @@ jobs:
 
       - name: Add Helm repositories
         run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo add valkey https://valkey-io.github.io/valkey-helm
           helm repo add mongodb https://mongodb.github.io/helm-charts
           helm repo update


### PR DESCRIPTION
## Summary

- Adds `helm repo add bitnami` to the release workflow's "Add Helm repositories" step
- The paperclip chart depends on `bitnami/postgresql` as a subchart, and chart-releaser needs the repo registered to package it
- This is the same fix already applied to `lint-test.yaml` via #33

## Test plan

- [x] Verified `release.yaml` has the bitnami repo added alongside valkey and mongodb
- [ ] Merge to main triggers a successful release workflow run

🤖 Generated with [Claude Code](https://claude.com/claude-code)