### PR TITLE
fix(paperclip): update image repository to osodevops fork

### DIFF
--- a/charts/paperclip/values.yaml
+++ b/charts/paperclip/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/paperclipai/paperclip
+  repository: ghcr.io/osodevops/docker-paperclip
   # -- Overrides the image tag whose default is the chart appVersion
   tag: ""
   pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary

- Updates `image.repository` from `ghcr.io/paperclipai/paperclip` to `ghcr.io/osodevops/docker-paperclip`
- Points at our fork at https://github.com/osodevops/docker-paperclip which builds and publishes the Docker image

## Test plan

- [x] `helm lint` passes
- [ ] Image available at `ghcr.io/osodevops/docker-paperclip` after docker-paperclip workflow runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)