### PR TITLE
fix(paperclip): fix security context and config mount for runtime

### DIFF
--- a/charts/paperclip/ci/test-values.yaml
+++ b/charts/paperclip/ci/test-values.yaml
@@ -11,6 +11,9 @@ storage:
 secrets:
   betterAuthSecret: "test-secret-do-not-use-in-production"
   masterKey: "dGVzdC1tYXN0ZXIta2V5LWRvLW5vdC11c2UtaW4tcHJvZA=="
+server:
+  publicUrl: "http://localhost:3100"
+  deploymentExposure: "public"
 ingress:
   enabled: false
 backup:

--- a/charts/paperclip/templates/configmap.yaml
+++ b/charts/paperclip/templates/configmap.yaml
@@ -11,7 +11,7 @@ data:
   SERVE_UI: {{ .Values.server.serveUi | quote }}
   PAPERCLIP_HOME: "/paperclip"
   PAPERCLIP_INSTANCE_ID: {{ .Values.server.instanceId | quote }}
-  PAPERCLIP_CONFIG: "/paperclip/instances/default/config.json"
+  PAPERCLIP_CONFIG: "/etc/paperclip/config.json"
   PAPERCLIP_DEPLOYMENT_MODE: {{ .Values.server.deploymentMode | quote }}
   PAPERCLIP_DEPLOYMENT_EXPOSURE: {{ .Values.server.deploymentExposure | quote }}
   {{- if .Values.server.publicUrl }}

--- a/charts/paperclip/templates/deployment.yaml
+++ b/charts/paperclip/templates/deployment.yaml
@@ -139,7 +139,7 @@ spec:
             - name: data
               mountPath: /paperclip
             - name: config-json
-              mountPath: /paperclip/instances/default/config.json
+              mountPath: /etc/paperclip/config.json
               subPath: config.json
               readOnly: true
             {{- with .Values.extraVolumeMounts }}

--- a/charts/paperclip/values.yaml
+++ b/charts/paperclip/values.yaml
@@ -278,18 +278,17 @@ initContainers: []
 sidecars: []
 
 # -- Pod security context
+# The entrypoint uses gosu to switch from root to node (UID 1000).
+# The container starts as root, then drops privileges at runtime.
 podSecurityContext:
-  runAsNonRoot: true
-  runAsUser: 1000
-  runAsGroup: 1000
+  runAsNonRoot: false
   fsGroup: 1000
   fsGroupChangePolicy: OnRootMismatch
   seccompProfile:
     type: RuntimeDefault
 
 # -- Container security context
+# allowPrivilegeEscalation is required for gosu to switch users.
 containerSecurityContext:
-  allowPrivilegeEscalation: false
+  allowPrivilegeEscalation: true
   readOnlyRootFilesystem: false
-  capabilities:
-    drop: ["ALL"]


### PR DESCRIPTION
## Summary

Fixes discovered during minikube testing with the real Docker image:

- **Config mount path**: moved from `/paperclip/instances/default/config.json` to `/etc/paperclip/config.json` — subPath mount under the PVC was blocking directory creation by the app
- **Security context**: container must start as root so `gosu` in the entrypoint can switch to the `node` user (UID 1000). `fsGroup: 1000` ensures PVC is writable after the switch
- **CI test values**: added `publicUrl` and `deploymentExposure: public` so health probes pass in authenticated mode

## Test plan

- [x] Verified on minikube with `ghcr.io/osodevops/docker-paperclip:latest`
- [x] PostgreSQL connects and runs
- [x] `/api/health` returns `{"status":"ok","version":"0.3.1"}`
- [x] Plugin system initializes
- [x] Database backups enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)