### PR TITLE
chore(kafka-backup-enterprise): add chart v0.1.0

### DIFF
--- a/charts/kafka-backup-enterprise/.helmignore
+++ b/charts/kafka-backup-enterprise/.helmignore
@@ -1,0 +1,8 @@
+.DS_Store
+.git
+.gitignore
+*.swp
+*.bak
+*.tmp
+*.orig
+OWNERS

--- a/charts/kafka-backup-enterprise/Chart.yaml
+++ b/charts/kafka-backup-enterprise/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: kafka-backup-enterprise
+description: Enterprise Kafka backup with Schema Registry, RBAC, and encryption support
+type: application
+version: 0.1.0
+appVersion: "0.3.1"
+home: https://github.com/osodevops/kafka-backup-enterprise
+sources:
+  - https://github.com/osodevops/kafka-backup-enterprise
+maintainers:
+  - name: OSO DevOps
+    email: dev@oso.sh
+    url: https://oso.sh
+keywords:
+  - kafka
+  - backup
+  - restore
+  - enterprise
+  - schema-registry
+  - disaster-recovery
+icon: https://raw.githubusercontent.com/osodevops/kafka-backup-enterprise/main/docs/icon.png
+annotations:
+  category: Infrastructure

--- a/charts/kafka-backup-enterprise/templates/NOTES.txt
+++ b/charts/kafka-backup-enterprise/templates/NOTES.txt
@@ -1,0 +1,57 @@
+Thank you for installing {{ .Chart.Name }}!
+
+Your release is named: {{ .Release.Name }}
+
+{{- if .Values.cronjob.enabled }}
+
+SCHEDULED BACKUP:
+  Schedule: {{ .Values.cronjob.schedule }}
+
+  View CronJob status:
+    kubectl get cronjob {{ include "kafka-backup-enterprise.fullname" . }} -n {{ .Release.Namespace }}
+
+  View job history:
+    kubectl get jobs -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }}
+
+  View logs from last run:
+    kubectl logs -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} --tail=100
+
+  Trigger a backup immediately:
+    kubectl create job --from=cronjob/{{ include "kafka-backup-enterprise.fullname" . }} {{ include "kafka-backup-enterprise.fullname" . }}-manual-$(date +%s) -n {{ .Release.Namespace }}
+{{- end }}
+
+{{- if .Values.job.enabled }}
+
+ONE-SHOT {{ upper .Values.job.command }}:
+  Check status:
+    kubectl get job {{ include "kafka-backup-enterprise.fullname" . }}-job -n {{ .Release.Namespace }}
+  View logs:
+    kubectl logs -n {{ .Release.Namespace }} -l job-name={{ include "kafka-backup-enterprise.fullname" . }}-job -f
+{{- end }}
+
+{{- if not (or .Values.license.existingSecret .Values.license.key) }}
+
+LICENSE:
+  No license configured. The binary will run in auto-trial mode (14 days)
+  or OSS mode if the trial has expired.
+
+  To add a license:
+    kubectl create secret generic {{ include "kafka-backup-enterprise.fullname" . }}-license \
+      --from-literal=license-b64="$(base64 < license.lic)" \
+      -n {{ .Release.Namespace }}
+
+    Then upgrade with:
+      helm upgrade {{ .Release.Name }} ... --set license.existingSecret={{ include "kafka-backup-enterprise.fullname" . }}-license
+{{- end }}
+
+{{- if .Values.metrics.enabled }}
+
+Metrics are available at:
+  kubectl port-forward svc/{{ include "kafka-backup-enterprise.fullname" . }}-metrics {{ .Values.metrics.service.port }}:{{ .Values.metrics.service.port }} -n {{ .Release.Namespace }}
+  curl http://localhost:{{ .Values.metrics.service.port }}{{ .Values.metrics.path }}
+
+  Note: CronJob pods are ephemeral — metrics are only available while a backup is running.
+{{- end }}
+
+For more information, visit:
+  https://kafkabackup.com/enterprise

--- a/charts/kafka-backup-enterprise/templates/_helpers.tpl
+++ b/charts/kafka-backup-enterprise/templates/_helpers.tpl
@@ -1,0 +1,103 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kafka-backup-enterprise.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kafka-backup-enterprise.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kafka-backup-enterprise.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "kafka-backup-enterprise.labels" -}}
+helm.sh/chart: {{ include "kafka-backup-enterprise.chart" . }}
+{{ include "kafka-backup-enterprise.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kafka-backup-enterprise.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kafka-backup-enterprise.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "kafka-backup-enterprise.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "kafka-backup-enterprise.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the proper image name
+*/}}
+{{- define "kafka-backup-enterprise.image" -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end }}
+
+{{/*
+Return the ConfigMap name (existing or generated)
+*/}}
+{{- define "kafka-backup-enterprise.configMapName" -}}
+{{- if .Values.config.existingConfigMap }}
+{{- .Values.config.existingConfigMap }}
+{{- else }}
+{{- include "kafka-backup-enterprise.fullname" . }}-config
+{{- end }}
+{{- end }}
+
+{{/*
+Return the license Secret name (existing or generated)
+*/}}
+{{- define "kafka-backup-enterprise.licenseSecretName" -}}
+{{- if .Values.license.existingSecret }}
+{{- .Values.license.existingSecret }}
+{{- else }}
+{{- include "kafka-backup-enterprise.fullname" . }}-license
+{{- end }}
+{{- end }}
+
+{{/*
+Return the credentials Secret name (existing or generated)
+*/}}
+{{- define "kafka-backup-enterprise.credentialsSecretName" -}}
+{{- if .Values.credentials.existingSecret }}
+{{- .Values.credentials.existingSecret }}
+{{- else }}
+{{- include "kafka-backup-enterprise.fullname" . }}-credentials
+{{- end }}
+{{- end }}

--- a/charts/kafka-backup-enterprise/templates/configmap.yaml
+++ b/charts/kafka-backup-enterprise/templates/configmap.yaml
@@ -1,0 +1,11 @@
+{{- if not .Values.config.existingConfigMap }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "kafka-backup-enterprise.fullname" . }}-config
+  labels:
+    {{- include "kafka-backup-enterprise.labels" . | nindent 4 }}
+data:
+  backup.yaml: |
+    {{- .Values.config.backupConfig | nindent 4 }}
+{{- end }}

--- a/charts/kafka-backup-enterprise/templates/cronjob.yaml
+++ b/charts/kafka-backup-enterprise/templates/cronjob.yaml
@@ -1,0 +1,127 @@
+{{- if .Values.cronjob.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "kafka-backup-enterprise.fullname" . }}
+  labels:
+    {{- include "kafka-backup-enterprise.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backup
+spec:
+  schedule: {{ .Values.cronjob.schedule | quote }}
+  {{- if .Values.cronjob.timeZone }}
+  timeZone: {{ .Values.cronjob.timeZone | quote }}
+  {{- end }}
+  concurrencyPolicy: {{ .Values.cronjob.concurrencyPolicy }}
+  startingDeadlineSeconds: {{ .Values.cronjob.startingDeadlineSeconds }}
+  successfulJobsHistoryLimit: {{ .Values.cronjob.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.cronjob.failedJobsHistoryLimit }}
+  suspend: {{ .Values.cronjob.suspend }}
+  jobTemplate:
+    spec:
+      {{- if .Values.cronjob.activeDeadlineSeconds }}
+      activeDeadlineSeconds: {{ .Values.cronjob.activeDeadlineSeconds }}
+      {{- end }}
+      backoffLimit: {{ .Values.cronjob.backoffLimit }}
+      {{- if .Values.cronjob.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ .Values.cronjob.ttlSecondsAfterFinished }}
+      {{- end }}
+      template:
+        metadata:
+          labels:
+            {{- include "kafka-backup-enterprise.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: backup
+            {{- with .Values.podLabels }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if or .Values.metrics.enabled .Values.podAnnotations }}
+          annotations:
+            {{- if .Values.metrics.enabled }}
+            prometheus.io/scrape: "true"
+            prometheus.io/port: {{ .Values.metrics.port | quote }}
+            prometheus.io/path: {{ .Values.metrics.path | quote }}
+            {{- end }}
+            {{- with .Values.podAnnotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+        spec:
+          restartPolicy: {{ .Values.cronjob.restartPolicy }}
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          serviceAccountName: {{ include "kafka-backup-enterprise.serviceAccountName" . }}
+          securityContext:
+            {{- toYaml .Values.podSecurityContext | nindent 12 }}
+          containers:
+            - name: kafka-backup
+              image: {{ include "kafka-backup-enterprise.image" . }}
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              args:
+                - backup
+                - --config
+                - /config/backup.yaml
+              env:
+                - name: RUST_LOG
+                  value: {{ .Values.logging.level | quote }}
+                {{- if or .Values.license.existingSecret .Values.license.key }}
+                - name: ENTERPRISE_LICENSE_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "kafka-backup-enterprise.licenseSecretName" . }}
+                      key: {{ .Values.license.existingSecretKey | default "license-b64" }}
+                {{- end }}
+                {{- with .Values.extraEnv }}
+                {{- toYaml . | nindent 16 }}
+                {{- end }}
+              {{- if or .Values.credentials.existingSecret .Values.credentials.inline }}
+              envFrom:
+                - secretRef:
+                    name: {{ include "kafka-backup-enterprise.credentialsSecretName" . }}
+              {{- end }}
+              {{- with .Values.resources }}
+              resources:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+              securityContext:
+                {{- toYaml .Values.securityContext | nindent 16 }}
+              volumeMounts:
+                - name: config
+                  mountPath: /config
+                  readOnly: true
+                - name: tmp
+                  mountPath: /tmp
+                {{- if .Values.trialPersistence.enabled }}
+                - name: trial-state
+                  mountPath: /var/lib/kafka-backup
+                {{- end }}
+                {{- with .Values.extraVolumeMounts }}
+                {{- toYaml . | nindent 16 }}
+                {{- end }}
+          volumes:
+            - name: config
+              configMap:
+                name: {{ include "kafka-backup-enterprise.configMapName" . }}
+            - name: tmp
+              emptyDir: {}
+            {{- if .Values.trialPersistence.enabled }}
+            - name: trial-state
+              persistentVolumeClaim:
+                claimName: {{ include "kafka-backup-enterprise.fullname" . }}-trial
+            {{- end }}
+            {{- with .Values.extraVolumes }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/charts/kafka-backup-enterprise/templates/job.yaml
+++ b/charts/kafka-backup-enterprise/templates/job.yaml
@@ -1,0 +1,119 @@
+{{- if .Values.job.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "kafka-backup-enterprise.fullname" . }}-job
+  labels:
+    {{- include "kafka-backup-enterprise.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ .Values.job.command }}
+spec:
+  {{- if .Values.job.activeDeadlineSeconds }}
+  activeDeadlineSeconds: {{ .Values.job.activeDeadlineSeconds }}
+  {{- end }}
+  backoffLimit: {{ .Values.job.backoffLimit }}
+  {{- if .Values.job.ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ .Values.job.ttlSecondsAfterFinished }}
+  {{- end }}
+  template:
+    metadata:
+      labels:
+        {{- include "kafka-backup-enterprise.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: {{ .Values.job.command }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- if or .Values.metrics.enabled .Values.podAnnotations }}
+      annotations:
+        {{- if .Values.metrics.enabled }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: {{ .Values.metrics.port | quote }}
+        prometheus.io/path: {{ .Values.metrics.path | quote }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+    spec:
+      restartPolicy: {{ .Values.job.restartPolicy }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "kafka-backup-enterprise.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: kafka-backup
+          image: {{ include "kafka-backup-enterprise.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - {{ .Values.job.command }}
+            - --config
+            - /config/backup.yaml
+            {{- range .Values.job.extraArgs }}
+            - {{ . | quote }}
+            {{- end }}
+          env:
+            - name: RUST_LOG
+              value: {{ .Values.logging.level | quote }}
+            {{- if or .Values.license.existingSecret .Values.license.key }}
+            - name: ENTERPRISE_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kafka-backup-enterprise.licenseSecretName" . }}
+                  key: {{ .Values.license.existingSecretKey | default "license-b64" }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- if or .Values.credentials.existingSecret .Values.credentials.inline }}
+          envFrom:
+            - secretRef:
+                name: {{ include "kafka-backup-enterprise.credentialsSecretName" . }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /config
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+            {{- if .Values.trialPersistence.enabled }}
+            - name: trial-state
+              mountPath: /var/lib/kafka-backup
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "kafka-backup-enterprise.configMapName" . }}
+        - name: tmp
+          emptyDir: {}
+        {{- if .Values.trialPersistence.enabled }}
+        - name: trial-state
+          persistentVolumeClaim:
+            claimName: {{ include "kafka-backup-enterprise.fullname" . }}-trial
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/kafka-backup-enterprise/templates/pvc.yaml
+++ b/charts/kafka-backup-enterprise/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.trialPersistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "kafka-backup-enterprise.fullname" . }}-trial
+  labels:
+    {{- include "kafka-backup-enterprise.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.trialPersistence.accessModes | nindent 4 }}
+  {{- if .Values.trialPersistence.storageClassName }}
+  storageClassName: {{ .Values.trialPersistence.storageClassName | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.trialPersistence.size }}
+{{- end }}

--- a/charts/kafka-backup-enterprise/templates/secret-credentials.yaml
+++ b/charts/kafka-backup-enterprise/templates/secret-credentials.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.credentials.inline (not .Values.credentials.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "kafka-backup-enterprise.fullname" . }}-credentials
+  labels:
+    {{- include "kafka-backup-enterprise.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- range $key, $value := .Values.credentials.inline }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/kafka-backup-enterprise/templates/secret-license.yaml
+++ b/charts/kafka-backup-enterprise/templates/secret-license.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.license.key (not .Values.license.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "kafka-backup-enterprise.fullname" . }}-license
+  labels:
+    {{- include "kafka-backup-enterprise.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{ .Values.license.existingSecretKey | default "license-b64" }}: {{ .Values.license.key | quote }}
+{{- end }}

--- a/charts/kafka-backup-enterprise/templates/service.yaml
+++ b/charts/kafka-backup-enterprise/templates/service.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.metrics.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kafka-backup-enterprise.fullname" . }}-metrics
+  labels:
+    {{- include "kafka-backup-enterprise.labels" . | nindent 4 }}
+  {{- with .Values.metrics.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.metrics.service.type }}
+  ports:
+    - port: {{ .Values.metrics.service.port }}
+      targetPort: {{ .Values.metrics.port }}
+      protocol: TCP
+      name: metrics
+  selector:
+    {{- include "kafka-backup-enterprise.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/kafka-backup-enterprise/templates/serviceaccount.yaml
+++ b/charts/kafka-backup-enterprise/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kafka-backup-enterprise.serviceAccountName" . }}
+  labels:
+    {{- include "kafka-backup-enterprise.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/kafka-backup-enterprise/templates/servicemonitor.yaml
+++ b/charts/kafka-backup-enterprise/templates/servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "kafka-backup-enterprise.fullname" . }}
+  labels:
+    {{- include "kafka-backup-enterprise.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "kafka-backup-enterprise.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      interval: {{ .Values.metrics.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+      path: {{ .Values.metrics.path }}
+{{- end }}

--- a/charts/kafka-backup-enterprise/values.yaml
+++ b/charts/kafka-backup-enterprise/values.yaml
@@ -1,0 +1,166 @@
+# Default values for kafka-backup-enterprise
+
+# ── CronJob Configuration ─────────────────────────────────────
+cronjob:
+  # Enable scheduled backups
+  enabled: true
+  # Cron schedule expression
+  schedule: "0 2 * * *"
+  # Timezone (Kubernetes 1.27+)
+  timeZone: ""
+  # Concurrency policy: Forbid, Replace, or Allow
+  concurrencyPolicy: Forbid
+  # Seconds after which a missed job is still started
+  startingDeadlineSeconds: 200
+  # Number of successful/failed jobs to keep
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  # Suspend the CronJob
+  suspend: false
+  # Backoff limit and active deadline
+  backoffLimit: 2
+  activeDeadlineSeconds: 7200
+  # Restart policy for the pod
+  restartPolicy: Never
+  # TTL for completed jobs (auto-cleanup)
+  ttlSecondsAfterFinished: 86400
+
+# ── Ad-hoc Job (one-shot backup or restore) ───────────────────
+job:
+  # Enable the one-shot Job (typically with cronjob.enabled: false)
+  enabled: false
+  # Command to run: "backup" or "restore"
+  command: backup
+  # Additional CLI arguments
+  extraArgs: []
+  backoffLimit: 0
+  activeDeadlineSeconds: 7200
+  restartPolicy: Never
+  ttlSecondsAfterFinished: 86400
+
+# ── Container image configuration ─────────────────────────────
+image:
+  repository: osodevops/kafka-backup-enterprise
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+# ── Service account ───────────────────────────────────────────
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account (e.g., IRSA, Workload Identity)
+  annotations: {}
+  # The name of the service account to use
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# ── Pod configuration ─────────────────────────────────────────
+podAnnotations: {}
+
+podLabels: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+resources: {}
+  # requests:
+  #   cpu: 100m
+  #   memory: 256Mi
+  # limits:
+  #   cpu: "1"
+  #   memory: 1Gi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# ── License ───────────────────────────────────────────────────
+license:
+  # Reference an existing Secret containing the license key
+  existingSecret: ""
+  # Key within the Secret (default: license-b64)
+  existingSecretKey: "license-b64"
+  # Inline license key (base64-encoded, for dev/test only)
+  key: ""
+
+# ── Backup configuration ─────────────────────────────────────
+config:
+  # The raw kafka-backup YAML config (rendered into ConfigMap)
+  # Use ${ENV_VAR} placeholders for secrets — the binary expands them at runtime
+  backupConfig: |
+    mode: backup
+    backup_id: "default-backup"
+    source:
+      bootstrap_servers:
+        - kafka:9092
+    storage:
+      backend: s3
+      bucket: kafka-backups
+      region: us-east-1
+  # Use an existing ConfigMap instead of creating one
+  existingConfigMap: ""
+
+# ── Credentials (injected as env vars for ${ENV_VAR} expansion) ─
+credentials:
+  # Reference an existing Secret containing credential env vars
+  existingSecret: ""
+  # Inline credentials (chart creates a Secret; for dev/test only)
+  inline: {}
+    # SR_USER: ""
+    # SR_PASS: ""
+    # MDS_USER: ""
+    # MDS_PASS: ""
+    # AWS_ACCESS_KEY_ID: ""
+    # AWS_SECRET_ACCESS_KEY: ""
+
+# ── Trial state persistence ───────────────────────────────────
+trialPersistence:
+  # Enable PVC for trial state file at /var/lib/kafka-backup
+  enabled: false
+  storageClassName: ""
+  size: 1Mi
+  accessModes:
+    - ReadWriteOnce
+
+# ── Logging configuration ────────────────────────────────────
+logging:
+  level: "info"
+
+# ── Metrics configuration ────────────────────────────────────
+metrics:
+  enabled: false
+  port: 8080
+  path: /metrics
+
+  service:
+    type: ClusterIP
+    port: 8080
+    annotations: {}
+
+  serviceMonitor:
+    enabled: false
+    interval: 30s
+    scrapeTimeout: 10s
+    labels: {}
+
+# ── Extension points ─────────────────────────────────────────
+extraEnv: []
+extraVolumeMounts: []
+extraVolumes: []


### PR DESCRIPTION
## Summary

- Add `kafka-backup-enterprise` Helm chart (v0.1.0, appVersion 0.3.1)
- Deploys the enterprise binary as a CronJob for scheduled Kafka backups
- Includes license injection, credential management, Prometheus metrics, and ServiceMonitor support
- Future releases will be synced automatically via the `helm-publish.yml` workflow in `osodevops/kafka-backup-enterprise`

## Install

Once merged and published:
```bash
helm repo add oso https://osodevops.github.io/helm-charts/
helm repo update
helm install kafka-backup oso/kafka-backup-enterprise --namespace kafka-backup
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)