### PR TITLE
chore(strimzi-backup-operator): sync chart v0.1.1

### DIFF
--- a/charts/strimzi-backup-operator/Chart.yaml
+++ b/charts/strimzi-backup-operator/Chart.yaml
@@ -1,11 +1,10 @@
 apiVersion: v2
 name: strimzi-backup-operator
-description: A Strimzi-native Kubernetes operator for Kafka backup and restore
+description: Kubernetes operator for Kafka backup and restore, integrated with Strimzi
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.1.1
+appVersion: "0.1.1"
 home: https://github.com/osodevops/strimzi-backup-operator
-icon: https://strimzi.io/assets/images/strimzi_logo.png
 sources:
   - https://github.com/osodevops/strimzi-backup-operator
 maintainers:
@@ -22,3 +21,4 @@ keywords:
   - disaster-recovery
 annotations:
   category: Infrastructure
+  artifacthub.io/disclaimer: "Not affiliated with the Strimzi project or CNCF"

--- a/charts/strimzi-backup-operator/crds/kafkabackups.yaml
+++ b/charts/strimzi-backup-operator/crds/kafkabackups.yaml
@@ -1,9 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: kafkabackups.backup.strimzi.io
+  name: kafkabackups.kafkabackup.com
 spec:
-  group: backup.strimzi.io
+  group: kafkabackup.com
   names:
     categories: []
     kind: KafkaBackup
@@ -100,10 +100,29 @@ spec:
                 description: Backup options (compression, encryption, parallelism)
                 nullable: true
                 properties:
+                  checkpointIntervalSecs:
+                    description: Checkpoint interval in seconds
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
                   compression:
-                    description: 'Compression algorithm: none, gzip, snappy, lz4, zstd'
+                    description: 'Compression algorithm: none, lz4, zstd'
                     nullable: true
                     type: string
+                  compressionLevel:
+                    description: 'Compression level (zstd: 1-22)'
+                    format: int32
+                    nullable: true
+                    type: integer
+                  consumerGroupSnapshot:
+                    description: Snapshot consumer group offsets after each backup cycle
+                    nullable: true
+                    type: boolean
+                  continuous:
+                    description: Run continuously instead of one-shot
+                    nullable: true
+                    type: boolean
                   encryption:
                     description: Encryption configuration
                     nullable: true
@@ -127,9 +146,34 @@ spec:
                         - name
                         type: object
                     type: object
+                  includeInternalTopics:
+                    description: Include internal Kafka topics
+                    nullable: true
+                    type: boolean
+                  includeOffsetHeaders:
+                    description: Include original Kafka offset headers in backup records
+                    nullable: true
+                    type: boolean
+                  internalTopics:
+                    description: Internal topics to include
+                    items:
+                      type: string
+                    type: array
                   parallelism:
                     description: 'Number of concurrent partition backup threads (default: 4)'
                     format: int32
+                    nullable: true
+                    type: integer
+                  pollIntervalMs:
+                    description: Continuous-mode poll interval in milliseconds
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  segmentMaxIntervalMs:
+                    description: Maximum segment time interval in milliseconds
+                    format: uint64
+                    minimum: 0.0
                     nullable: true
                     type: integer
                   segmentSize:
@@ -137,6 +181,55 @@ spec:
                     format: int64
                     nullable: true
                     type: integer
+                  sourceClusterId:
+                    description: Source cluster identifier written to record headers
+                    nullable: true
+                    type: string
+                  startOffset:
+                    description: 'Starting offset for backups: earliest or latest'
+                    nullable: true
+                    type: string
+                  stopAtCurrentOffsets:
+                    description: Snapshot current high watermarks and exit when caught up
+                    nullable: true
+                    type: boolean
+                  syncIntervalSecs:
+                    description: Remote offset database sync interval in seconds
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                type: object
+              connection:
+                description: Kafka connection tuning for the source cluster
+                nullable: true
+                properties:
+                  connectionsPerBroker:
+                    description: TCP connections to keep per broker
+                    format: uint
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  keepaliveIntervalSecs:
+                    description: Seconds between keepalive probes
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  keepaliveTimeSecs:
+                    description: Seconds before the first keepalive probe
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  tcpKeepalive:
+                    description: Enable TCP keepalive
+                    nullable: true
+                    type: boolean
+                  tcpNodelay:
+                    description: Enable TCP_NODELAY
+                    nullable: true
+                    type: boolean
                 type: object
               consumerGroups:
                 description: Consumer group selection
@@ -157,6 +250,64 @@ spec:
                 description: 'Container image for the backup job (default: ghcr.io/osodevops/kafka-backup:latest)'
                 nullable: true
                 type: string
+              metrics:
+                description: Metrics configuration for backup job pods
+                nullable: true
+                properties:
+                  bindAddress:
+                    description: Metrics bind address
+                    nullable: true
+                    type: string
+                  enabled:
+                    description: Enable the kafka-backup metrics server
+                    nullable: true
+                    type: boolean
+                  maxPartitionLabels:
+                    description: Maximum topic/partition labels emitted by the core metrics registry
+                    format: uint
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  path:
+                    description: Metrics endpoint path
+                    nullable: true
+                    type: string
+                  port:
+                    description: Metrics HTTP port
+                    format: uint16
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  updateIntervalMs:
+                    description: Metrics recalculation interval in milliseconds
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                type: object
+              offsetStorage:
+                description: Offset storage configuration for continuous backup progress
+                nullable: true
+                properties:
+                  backend:
+                    description: 'Offset storage backend: sqlite or memory'
+                    nullable: true
+                    type: string
+                  dbPath:
+                    description: Path to the local SQLite database file
+                    nullable: true
+                    type: string
+                  s3Key:
+                    description: Remote S3 key used to sync the offset database
+                    nullable: true
+                    type: string
+                  syncIntervalSecs:
+                    description: Remote sync interval in seconds
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                type: object
               resources:
                 description: Resource requirements for backup pods
                 nullable: true
@@ -215,6 +366,38 @@ spec:
                     description: Azure Blob Storage configuration
                     nullable: true
                     properties:
+                      accountKeySecret:
+                        description: Storage account key secret
+                        nullable: true
+                        properties:
+                          key:
+                            description: Key within the secret
+                            type: string
+                          name:
+                            description: Secret name
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      clientId:
+                        description: Azure AD client ID
+                        nullable: true
+                        type: string
+                      clientSecretSecret:
+                        description: Service principal client secret
+                        nullable: true
+                        properties:
+                          key:
+                            description: Key within the secret
+                            type: string
+                          name:
+                            description: Secret name
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
                       container:
                         description: Azure blob container name
                         type: string
@@ -232,16 +415,52 @@ spec:
                         - key
                         - name
                         type: object
+                      endpoint:
+                        description: Custom endpoint for sovereign clouds
+                        nullable: true
+                        type: string
                       prefix:
                         description: Key prefix within the container
                         nullable: true
                         type: string
+                      sasTokenSecret:
+                        description: SAS token secret
+                        nullable: true
+                        properties:
+                          key:
+                            description: Key within the secret
+                            type: string
+                          name:
+                            description: Secret name
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
                       storageAccount:
                         description: Azure storage account name
                         type: string
+                      tenantId:
+                        description: Azure AD tenant ID
+                        nullable: true
+                        type: string
+                      useWorkloadIdentity:
+                        description: Enable Azure Workload Identity
+                        nullable: true
+                        type: boolean
                     required:
                     - container
                     - storageAccount
+                    type: object
+                  filesystem:
+                    description: Filesystem storage configuration
+                    nullable: true
+                    properties:
+                      path:
+                        description: Base path for backup data
+                        type: string
+                    required:
+                    - path
                     type: object
                   gcs:
                     description: Google Cloud Storage configuration
@@ -268,6 +487,10 @@ spec:
                         description: Key prefix within the bucket
                         nullable: true
                         type: string
+                      serviceAccountPath:
+                        description: Path to a mounted service account JSON file
+                        nullable: true
+                        type: string
                     required:
                     - bucket
                     type: object
@@ -275,6 +498,24 @@ spec:
                     description: S3-compatible storage configuration
                     nullable: true
                     properties:
+                      accessKeySecret:
+                        description: Secret key containing AWS access key ID
+                        nullable: true
+                        properties:
+                          key:
+                            description: Key within the secret
+                            type: string
+                          name:
+                            description: Secret name
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
+                      allowHttp:
+                        description: Allow insecure HTTP connections
+                        nullable: true
+                        type: boolean
                       bucket:
                         description: S3 bucket name
                         type: string
@@ -308,6 +549,20 @@ spec:
                         description: AWS region
                         nullable: true
                         type: string
+                      secretKeySecret:
+                        description: Secret key containing AWS secret access key
+                        nullable: true
+                        properties:
+                          key:
+                            description: Key within the secret
+                            type: string
+                          name:
+                            description: Secret name
+                            type: string
+                        required:
+                        - key
+                        - name
+                        type: object
                     required:
                     - bucket
                     type: object
@@ -317,6 +572,7 @@ spec:
                     - s3
                     - azure
                     - gcs
+                    - filesystem
                     type: string
                 required:
                 - type
@@ -324,6 +580,20 @@ spec:
               strimziClusterRef:
                 description: Reference to the Strimzi Kafka cluster CR
                 properties:
+                  caSecret:
+                    description: Optional override for the cluster CA secret. Defaults to the Strimzi convention `{name}-cluster-ca-cert` with key `ca.crt`. Useful when the CA is stored in a differently-named secret, or when the key inside the secret is not `ca.crt`.
+                    nullable: true
+                    properties:
+                      key:
+                        description: Key within the secret
+                        type: string
+                      name:
+                        description: Secret name
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
                   name:
                     description: Name of the Kafka CR
                     type: string
@@ -400,16 +670,16 @@ spec:
                     type: object
                 type: object
               topics:
-                description: Topic selection with include/exclude regex patterns
+                description: Topic selection with include/exclude glob patterns
                 nullable: true
                 properties:
                   exclude:
-                    description: Regex patterns for topics to exclude
+                    description: Glob patterns for topics to exclude
                     items:
                       type: string
                     type: array
                   include:
-                    description: Regex patterns for topics to include
+                    description: Glob patterns for topics to include
                     items:
                       type: string
                     type: array

--- a/charts/strimzi-backup-operator/crds/kafkarestores.yaml
+++ b/charts/strimzi-backup-operator/crds/kafkarestores.yaml
@@ -1,9 +1,9 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: kafkarestores.backup.strimzi.io
+  name: kafkarestores.kafkabackup.com
 spec:
-  group: backup.strimzi.io
+  group: kafkabackup.com
   names:
     categories: []
     kind: KafkaRestore
@@ -106,10 +106,50 @@ spec:
                 required:
                 - name
                 type: object
+              connection:
+                description: Kafka connection tuning for the target cluster
+                nullable: true
+                properties:
+                  connectionsPerBroker:
+                    description: TCP connections to keep per broker
+                    format: uint
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  keepaliveIntervalSecs:
+                    description: Seconds between keepalive probes
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  keepaliveTimeSecs:
+                    description: Seconds before the first keepalive probe
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  tcpKeepalive:
+                    description: Enable TCP keepalive
+                    nullable: true
+                    type: boolean
+                  tcpNodelay:
+                    description: Enable TCP_NODELAY
+                    nullable: true
+                    type: boolean
+                type: object
               consumerGroups:
                 description: Consumer group restore configuration
                 nullable: true
                 properties:
+                  auto:
+                    description: Automatically load the consumer group snapshot from backup storage
+                    nullable: true
+                    type: boolean
+                  groups:
+                    description: Consumer groups to reset
+                    items:
+                      type: string
+                    type: array
                   mapping:
                     description: Consumer group mappings (source → target)
                     items:
@@ -126,21 +166,68 @@ spec:
                       - targetGroup
                       type: object
                     type: array
+                  offsetReport:
+                    description: Output file path for offset mapping report
+                    nullable: true
+                    type: string
                   restore:
                     default: false
                     description: Whether to restore consumer group offsets
                     type: boolean
+                  strategy:
+                    description: 'Offset handling strategy: skip, header-based, timestamp-based, cluster-scan, manual'
+                    nullable: true
+                    type: string
                 type: object
               image:
                 description: 'Container image for the restore job (default: ghcr.io/osodevops/kafka-backup:latest)'
                 nullable: true
                 type: string
+              metrics:
+                description: Metrics configuration for restore job pods
+                nullable: true
+                properties:
+                  bindAddress:
+                    description: Metrics bind address
+                    nullable: true
+                    type: string
+                  enabled:
+                    description: Enable the kafka-backup metrics server
+                    nullable: true
+                    type: boolean
+                  maxPartitionLabels:
+                    description: Maximum topic/partition labels emitted by the core metrics registry
+                    format: uint
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  path:
+                    description: Metrics endpoint path
+                    nullable: true
+                    type: string
+                  port:
+                    description: Metrics HTTP port
+                    format: uint16
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  updateIntervalMs:
+                    description: Metrics recalculation interval in milliseconds
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                type: object
               pointInTime:
                 description: Point-in-time recovery settings
                 nullable: true
                 properties:
                   offsetFromEnd:
-                    description: Duration offset from backup end (e.g., "2h", "30m")
+                    description: Duration offset from backup end (not supported by the current kafka-backup core)
+                    nullable: true
+                    type: string
+                  startTimestamp:
+                    description: Start timestamp for the restore window (ISO 8601 with millisecond precision)
                     nullable: true
                     type: string
                   timestamp:
@@ -167,19 +254,119 @@ spec:
                 description: Restore behaviour options
                 nullable: true
                 properties:
+                  checkpointIntervalSecs:
+                    description: Checkpoint interval in seconds
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  checkpointState:
+                    description: Checkpoint state file path
+                    nullable: true
+                    type: string
+                  defaultReplicationFactor:
+                    description: Replication factor for auto-created topics
+                    format: int16
+                    nullable: true
+                    type: integer
+                  dryRun:
+                    description: 'Dry-run mode: validate without writing records'
+                    nullable: true
+                    type: boolean
                   existingTopicPolicy:
-                    description: 'Policy for existing topics: fail, append, or overwrite'
+                    description: 'Policy for existing topics: append or overwrite. fail is accepted for legacy CRs but rejected at runtime.'
                     enum:
                     - fail
                     - append
                     - overwrite
                     nullable: true
                     type: string
+                  includeOriginalOffsetHeader:
+                    description: Include original offsets as headers on restored records
+                    nullable: true
+                    type: boolean
                   parallelism:
                     description: 'Number of concurrent restore threads (default: 4)'
                     format: int32
                     nullable: true
                     type: integer
+                  partitionMapping:
+                    description: Partition mapping entries
+                    items:
+                      description: Mapping for source partition to target partition.
+                      properties:
+                        sourcePartition:
+                          description: Source partition number
+                          format: int32
+                          type: integer
+                        targetPartition:
+                          description: Target partition number
+                          format: int32
+                          type: integer
+                      required:
+                      - sourcePartition
+                      - targetPartition
+                      type: object
+                    type: array
+                  produceAcks:
+                    description: Producer acks setting (-1, 0, or 1)
+                    format: int16
+                    nullable: true
+                    type: integer
+                  produceBatchSize:
+                    description: Produce batch size
+                    format: uint
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  produceTimeoutMs:
+                    description: Broker-side produce timeout in milliseconds
+                    format: int32
+                    nullable: true
+                    type: integer
+                  purgeTopics:
+                    description: Purge target topics before restoring
+                    nullable: true
+                    type: boolean
+                  rateLimitBytesPerSec:
+                    description: Rate limit in bytes per second
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  rateLimitRecordsPerSec:
+                    description: Rate limit in records per second
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  repartitioning:
+                    description: Per-topic repartitioning configuration
+                    items:
+                      description: Per-topic repartitioning configuration keyed by target topic name.
+                      properties:
+                        strategy:
+                          description: 'Partitioning strategy: murmur2 or automatic'
+                          nullable: true
+                          type: string
+                        targetPartitions:
+                          description: Target partition count
+                          format: int32
+                          type: integer
+                        topic:
+                          description: Target topic name
+                          type: string
+                      required:
+                      - targetPartitions
+                      - topic
+                      type: object
+                    type: array
+                  sourcePartitions:
+                    description: Source partitions to restore
+                    items:
+                      format: int32
+                      type: integer
+                    type: array
                   topicCreation:
                     description: 'Topic creation strategy: auto or manual'
                     enum:
@@ -191,6 +378,20 @@ spec:
               strimziClusterRef:
                 description: Reference to the target Strimzi Kafka cluster CR
                 properties:
+                  caSecret:
+                    description: Optional override for the cluster CA secret. Defaults to the Strimzi convention `{name}-cluster-ca-cert` with key `ca.crt`. Useful when the CA is stored in a differently-named secret, or when the key inside the secret is not `ca.crt`.
+                    nullable: true
+                    properties:
+                      key:
+                        description: Key within the secret
+                        type: string
+                      name:
+                        description: Secret name
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
                   name:
                     description: Name of the Kafka CR
                     type: string

--- a/charts/strimzi-backup-operator/templates/NOTES.txt
+++ b/charts/strimzi-backup-operator/templates/NOTES.txt
@@ -7,12 +7,12 @@ To verify the installation, run:
   kubectl get pods -l "app.kubernetes.io/name={{ include "strimzi-backup-operator.name" . }},app.kubernetes.io/instance={{ .Release.Name }}"
 
 The operator is now watching for the following custom resources:
-  - KafkaBackup  (backup.strimzi.io/v1alpha1)
-  - KafkaRestore (backup.strimzi.io/v1alpha1)
+  - KafkaBackup  (kafkabackup.com/v1alpha1)
+  - KafkaRestore (kafkabackup.com/v1alpha1)
 
 To create a backup, apply a KafkaBackup resource:
 
-  apiVersion: backup.strimzi.io/v1alpha1
+  apiVersion: kafkabackup.com/v1alpha1
   kind: KafkaBackup
   metadata:
     name: my-cluster-backup
@@ -29,7 +29,7 @@ To create a backup, apply a KafkaBackup resource:
 
 To restore from a backup:
 
-  apiVersion: backup.strimzi.io/v1alpha1
+  apiVersion: kafkabackup.com/v1alpha1
   kind: KafkaRestore
   metadata:
     name: my-cluster-restore

--- a/charts/strimzi-backup-operator/templates/_helpers.tpl
+++ b/charts/strimzi-backup-operator/templates/_helpers.tpl
@@ -38,7 +38,7 @@ helm.sh/chart: {{ include "strimzi-backup-operator.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-app.kubernetes.io/part-of: strimzi-backup
+app.kubernetes.io/part-of: kafka-backup
 app.kubernetes.io/component: controller
 {{- end }}
 

--- a/charts/strimzi-backup-operator/templates/clusterrole.yaml
+++ b/charts/strimzi-backup-operator/templates/clusterrole.yaml
@@ -10,13 +10,13 @@ rules:
     resources: ["kafkas", "kafkatopics", "kafkausers"]
     verbs: ["get", "list", "watch"]
   # Manage backup CRDs
-  - apiGroups: ["backup.strimzi.io"]
+  - apiGroups: ["kafkabackup.com"]
     resources: ["kafkabackups", "kafkarestores"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  - apiGroups: ["backup.strimzi.io"]
+  - apiGroups: ["kafkabackup.com"]
     resources: ["kafkabackups/status", "kafkarestores/status"]
     verbs: ["get", "update", "patch"]
-  - apiGroups: ["backup.strimzi.io"]
+  - apiGroups: ["kafkabackup.com"]
     resources: ["kafkabackups/finalizers", "kafkarestores/finalizers"]
     verbs: ["update"]
   # Create backup/restore jobs

--- a/charts/strimzi-backup-operator/values.yaml
+++ b/charts/strimzi-backup-operator/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/osodevops/strimzi-backup-operator
+  repository: ghcr.io/osodevops/kafka-backup-operator
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion
   tag: ""
@@ -39,7 +39,7 @@ watchNamespaces: []
 
 # Logging configuration
 logging:
-  level: "info,strimzi_backup_operator=debug"
+  level: "info,kafka_backup_operator=debug"
   format: json
 
 # Pod annotations


### PR DESCRIPTION
## Summary

Automated sync of `strimzi-backup-operator` Helm chart.

**Chart Version:** `0.1.1`
**App Version:** `0.1.1`
**Source Commit:** [`b4f65d02233b2b876ec03a7cc2398ab645b75e6d`](https://github.com/osodevops/strimzi-backup-operator/commit/b4f65d02233b2b876ec03a7cc2398ab645b75e6d)

Replaces the stale CRDs (old `backup.strimzi.io` group) with the rebranded `kafkabackup.com` CRDs. Also publishes under the new chart path `charts/strimzi-backup-operator/` to avoid clashing with the other `kafka-backup-operator` chart.

Closes #39

---
*Auto-generated by [Helm Chart Sync Workflow](https://github.com/osodevops/strimzi-backup-operator/actions/runs/24690242815)*