### PR TITLE
chore(strimzi-backup-operator): sync chart v0.2.1

### DIFF
--- a/charts/strimzi-backup-operator/Chart.yaml
+++ b/charts/strimzi-backup-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: strimzi-backup-operator
 description: Kubernetes operator for Kafka backup and restore, integrated with Strimzi
 type: application
-version: 0.1.1
-appVersion: "0.1.1"
+version: 0.2.1
+appVersion: "0.2.1"
 home: https://github.com/osodevops/strimzi-backup-operator
 sources:
   - https://github.com/osodevops/strimzi-backup-operator

--- a/charts/strimzi-backup-operator/values.yaml
+++ b/charts/strimzi-backup-operator/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/osodevops/kafka-backup-operator
+  repository: ghcr.io/osodevops/strimzi-backup-operator
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion
   tag: ""


### PR DESCRIPTION
## Summary

Automated sync of `strimzi-backup-operator` Helm chart.

**Chart Version:** `0.2.1`
**App Version:** `0.2.1`
**Source Commit:** [`4c1f5c4231132f6cd2dd17bf74ea146670bec532`](https://github.com/osodevops/strimzi-backup-operator/commit/4c1f5c4231132f6cd2dd17bf74ea146670bec532)

---
*Auto-generated by [Helm Chart Sync Workflow](https://github.com/osodevops/strimzi-backup-operator/actions/runs/24708794160)*