### PR TITLE
chore(kafka-backup-operator): sync chart v1.0.3

### DIFF
--- a/charts/kafka-backup-operator/Chart.yaml
+++ b/charts/kafka-backup-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kafka-backup-operator
 description: A Kubernetes operator for managing Kafka backup and restore operations
 type: application
-version: 1.0.0
-appVersion: "1.0.0"
+version: 1.0.3
+appVersion: "1.0.3"
 home: https://github.com/osodevops/kafka-backup-operator
 sources:
   - https://github.com/osodevops/kafka-backup-operator

--- a/charts/kafka-backup-operator/crds/all.yaml
+++ b/charts/kafka-backup-operator/crds/all.yaml
@@ -129,6 +129,20 @@ spec:
                     items:
                       type: string
                     type: array
+                  caSecret:
+                    description: Separate CA certificate secret (overrides caKey in tlsSecret when both are set). Useful for Strimzi where the cluster CA and client certificates are in separate secrets.
+                    nullable: true
+                    properties:
+                      caKey:
+                        default: ca.crt
+                        description: Key within the secret for the CA certificate PEM
+                        type: string
+                      name:
+                        description: Secret name containing the CA certificate
+                        type: string
+                    required:
+                    - name
+                    type: object
                   connection:
                     description: Kafka TCP connection tuning
                     nullable: true
@@ -568,6 +582,11 @@ spec:
                 format: date-time
                 nullable: true
                 type: string
+              lastScheduleTime:
+                description: Authoritative timestamp of the most recent scheduled tick the operator has begun processing. Modelled on Kubernetes CronJob's `.status.lastScheduleTime`. Used as the monotonic anchor in `should_run_backup` so scheduling is immune to reflector-cache lag between a tick's `Running` patch and its `Completed` patch.
+                format: date-time
+                nullable: true
+                type: string
               message:
                 description: Human-readable message
                 nullable: true
@@ -932,6 +951,20 @@ spec:
                     items:
                       type: string
                     type: array
+                  caSecret:
+                    description: Separate CA certificate secret (overrides caKey in tlsSecret when both are set). Useful for Strimzi where the cluster CA and client certificates are in separate secrets.
+                    nullable: true
+                    properties:
+                      caKey:
+                        default: ca.crt
+                        description: Key within the secret for the CA certificate PEM
+                        type: string
+                      name:
+                        description: Secret name containing the CA certificate
+                        type: string
+                    required:
+                    - name
+                    type: object
                   connection:
                     description: Kafka TCP connection tuning
                     nullable: true
@@ -1084,7 +1117,7 @@ spec:
                 type: integer
               purgeTopics:
                 default: false
-                description: Purge target topics before restore using Kafka DeleteRecords
+                description: Purge target topics before restore using Kafka DeleteRecords. Required for restore-all or explicit same-topic restores.
                 type: boolean
               rateLimiting:
                 description: Rate limiting configuration
@@ -1369,6 +1402,20 @@ spec:
                     items:
                       type: string
                     type: array
+                  caSecret:
+                    description: Separate CA certificate secret (overrides caKey in tlsSecret when both are set). Useful for Strimzi where the cluster CA and client certificates are in separate secrets.
+                    nullable: true
+                    properties:
+                      caKey:
+                        default: ca.crt
+                        description: Key within the secret for the CA certificate PEM
+                        type: string
+                      name:
+                        description: Secret name containing the CA certificate
+                        type: string
+                    required:
+                    - name
+                    type: object
                   connection:
                     description: Kafka TCP connection tuning
                     nullable: true
@@ -1681,6 +1728,20 @@ spec:
                     items:
                       type: string
                     type: array
+                  caSecret:
+                    description: Separate CA certificate secret (overrides caKey in tlsSecret when both are set). Useful for Strimzi where the cluster CA and client certificates are in separate secrets.
+                    nullable: true
+                    properties:
+                      caKey:
+                        default: ca.crt
+                        description: Key within the secret for the CA certificate PEM
+                        type: string
+                      name:
+                        description: Secret name containing the CA certificate
+                        type: string
+                    required:
+                    - name
+                    type: object
                   connection:
                     description: Kafka TCP connection tuning
                     nullable: true
@@ -2482,6 +2543,20 @@ spec:
                     items:
                       type: string
                     type: array
+                  caSecret:
+                    description: Separate CA certificate secret (overrides caKey in tlsSecret when both are set). Useful for Strimzi where the cluster CA and client certificates are in separate secrets.
+                    nullable: true
+                    properties:
+                      caKey:
+                        default: ca.crt
+                        description: Key within the secret for the CA certificate PEM
+                        type: string
+                      name:
+                        description: Secret name containing the CA certificate
+                        type: string
+                    required:
+                    - name
+                    type: object
                   connection:
                     description: Kafka TCP connection tuning
                     nullable: true


### PR DESCRIPTION
## Summary

Automated sync of `kafka-backup-operator` Helm chart.

**Chart Version:** `1.0.3`
**App Version:** `1.0.3`
**Source Commit:** [`3eba715b5993eae0b55e0409436471765077afc9`](https://github.com/osodevops/kafka-backup-operator/commit/3eba715b5993eae0b55e0409436471765077afc9)
**Source Release:** [v1.0.3](https://github.com/osodevops/kafka-backup-operator/releases/tag/v1.0.3)

Image `ghcr.io/osodevops/kafka-backup-operator:1.0.3` was published by the upstream release workflow before this PR was opened.

---
*Auto-generated by [Release Workflow](https://github.com/osodevops/kafka-backup-operator/actions/runs/25217265297)*