### PR TITLE
chore(strimzi-backup-operator): sync chart v0.2.2

### DIFF
--- a/charts/strimzi-backup-operator/Chart.yaml
+++ b/charts/strimzi-backup-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: strimzi-backup-operator
 description: Kubernetes operator for Kafka backup and restore, integrated with Strimzi
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: "0.2.1"
 home: https://github.com/osodevops/strimzi-backup-operator
 sources:

--- a/charts/strimzi-backup-operator/crds/kafkabackups.yaml
+++ b/charts/strimzi-backup-operator/crds/kafkabackups.yaml
@@ -247,7 +247,7 @@ spec:
                     type: array
                 type: object
               image:
-                description: 'Container image for the backup job (default: ghcr.io/osodevops/kafka-backup:latest)'
+                description: 'Container image for the backup job (default: osodevops/kafka-backup:v0.15.3)'
                 nullable: true
                 type: string
               metrics:

--- a/charts/strimzi-backup-operator/crds/kafkarestores.yaml
+++ b/charts/strimzi-backup-operator/crds/kafkarestores.yaml
@@ -180,7 +180,7 @@ spec:
                     type: string
                 type: object
               image:
-                description: 'Container image for the restore job (default: ghcr.io/osodevops/kafka-backup:latest)'
+                description: 'Container image for the restore job (default: osodevops/kafka-backup:v0.15.3)'
                 nullable: true
                 type: string
               metrics:

--- a/charts/strimzi-backup-operator/templates/deployment.yaml
+++ b/charts/strimzi-backup-operator/templates/deployment.yaml
@@ -51,6 +51,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: BACKUP_JOB_SERVICE_ACCOUNT
+              value: {{ default (include "strimzi-backup-operator.serviceAccountName" .) .Values.backupJobs.serviceAccountName | quote }}
             {{- if .Values.watchNamespaces }}
             - name: STRIMZI_BACKUP_NAMESPACE
               value: {{ join "," .Values.watchNamespaces | quote }}

--- a/charts/strimzi-backup-operator/values.yaml
+++ b/charts/strimzi-backup-operator/values.yaml
@@ -24,6 +24,11 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+backupJobs:
+  # Service account used by backup and restore job pods.
+  # If empty, the chart passes the operator service account name.
+  serviceAccountName: ""
+
 # Azure Workload Identity configuration
 # When enabled, the operator can authenticate to Azure services using federated identity tokens
 # instead of storing credentials in Kubernetes secrets


### PR DESCRIPTION
## Summary

Sync of `strimzi-backup-operator` Helm chart after merging the operator fixes.

**Chart Version:** `0.2.2`
**App Version:** `0.2.1`
**Source Commit:** [`b418c35a0445cc6f912817760545ce6efc4d4865`](https://github.com/osodevops/strimzi-backup-operator/commit/b418c35a0445cc6f912817760545ce6efc4d4865)

## Notes

The synced chart content changed while the upstream app version stayed `0.2.1`, so the chart package version was bumped to `0.2.2` to satisfy chart-testing and publish a new chart artifact.

---
*Originally auto-generated by [Helm Chart Sync Workflow](https://github.com/osodevops/strimzi-backup-operator/actions/runs/25041073596).*