### PR TITLE
chore(kafka-backup-operator): sync chart v1.0.7

### DIFF
--- a/charts/kafka-backup-operator/Chart.yaml
+++ b/charts/kafka-backup-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kafka-backup-operator
 description: A Kubernetes operator for managing Kafka backup and restore operations
 type: application
-version: 1.0.3
-appVersion: "1.0.3"
+version: 1.0.7
+appVersion: "1.0.7"
 home: https://github.com/osodevops/kafka-backup-operator
 sources:
   - https://github.com/osodevops/kafka-backup-operator


### PR DESCRIPTION
## Summary

Automated sync of `kafka-backup-operator` Helm chart.

**Chart Version:** `1.0.7`
**App Version:** `1.0.7`
**Source Commit:** [`0bc15e1442ebc95667af0d57325ba6757ba2ad45`](https://github.com/osodevops/kafka-backup-operator/commit/0bc15e1442ebc95667af0d57325ba6757ba2ad45)
**Source Release:** [v1.0.7](https://github.com/osodevops/kafka-backup-operator/releases/tag/v1.0.7)

Image `ghcr.io/osodevops/kafka-backup-operator:1.0.7` was published by the upstream release workflow before this PR was opened.

---
*Auto-generated by [Release Workflow](https://github.com/osodevops/kafka-backup-operator/actions/runs/25983721353)*