### PR TITLE
chore(strimzi-backup-operator): sync chart v0.2.5

### DIFF
--- a/charts/strimzi-backup-operator/Chart.yaml
+++ b/charts/strimzi-backup-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: strimzi-backup-operator
 description: Kubernetes operator for Kafka backup and restore, integrated with Strimzi
 type: application
-version: 0.2.3
-appVersion: "0.2.2"
+version: 0.2.5
+appVersion: "0.2.5"
 home: https://github.com/osodevops/strimzi-backup-operator
 sources:
   - https://github.com/osodevops/strimzi-backup-operator

--- a/charts/strimzi-backup-operator/crds/kafkabackups.yaml
+++ b/charts/strimzi-backup-operator/crds/kafkabackups.yaml
@@ -246,10 +246,55 @@ spec:
                       type: string
                     type: array
                 type: object
+              env:
+                description: Additional environment variables for backup job pods
+                items:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                type: array
               image:
-                description: 'Container image for the backup job (default: osodevops/kafka-backup:v0.15.3)'
+                description: 'Container image for the backup job (default: osodevops/kafka-backup:v0.15.6)'
                 nullable: true
                 type: string
+              logging:
+                description: Logging configuration for backup job pods
+                nullable: true
+                properties:
+                  format:
+                    description: 'Log format: text or json'
+                    nullable: true
+                    type: string
+                  level:
+                    description: 'Default log level: error, warn, info, debug, or trace'
+                    nullable: true
+                    type: string
+                  modules:
+                    additionalProperties:
+                      type: string
+                    description: Module-specific log levels
+                    type: object
+                  output:
+                    description: 'Log output: stderr, stdout, or a file path supported by kafka-backup'
+                    nullable: true
+                    type: string
+                  rotation:
+                    description: File log rotation settings
+                    nullable: true
+                    properties:
+                      maxFiles:
+                        description: Maximum number of rotated log files to keep
+                        format: uint32
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
+                      maxSizeMb:
+                        description: Maximum size of a log file before rotation, in MiB
+                        format: uint64
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
+                    type: object
+                type: object
               metrics:
                 description: Metrics configuration for backup job pods
                 nullable: true

--- a/charts/strimzi-backup-operator/crds/kafkarestores.yaml
+++ b/charts/strimzi-backup-operator/crds/kafkarestores.yaml
@@ -179,10 +179,55 @@ spec:
                     nullable: true
                     type: string
                 type: object
+              env:
+                description: Additional environment variables for restore job pods
+                items:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                type: array
               image:
-                description: 'Container image for the restore job (default: osodevops/kafka-backup:v0.15.3)'
+                description: 'Container image for the restore job (default: osodevops/kafka-backup:v0.15.6)'
                 nullable: true
                 type: string
+              logging:
+                description: Logging configuration for restore job pods
+                nullable: true
+                properties:
+                  format:
+                    description: 'Log format: text or json'
+                    nullable: true
+                    type: string
+                  level:
+                    description: 'Default log level: error, warn, info, debug, or trace'
+                    nullable: true
+                    type: string
+                  modules:
+                    additionalProperties:
+                      type: string
+                    description: Module-specific log levels
+                    type: object
+                  output:
+                    description: 'Log output: stderr, stdout, or a file path supported by kafka-backup'
+                    nullable: true
+                    type: string
+                  rotation:
+                    description: File log rotation settings
+                    nullable: true
+                    properties:
+                      maxFiles:
+                        description: Maximum number of rotated log files to keep
+                        format: uint32
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
+                      maxSizeMb:
+                        description: Maximum size of a log file before rotation, in MiB
+                        format: uint64
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
+                    type: object
+                type: object
               metrics:
                 description: Metrics configuration for restore job pods
                 nullable: true


### PR DESCRIPTION
## Summary

Automated sync of `strimzi-backup-operator` Helm chart.

**Chart Version:** `0.2.5`
**App Version:** `0.2.5`
**Source Commit:** [`6b1c4e83b37ca8b27afb1dc46ca20287d0d85f89`](https://github.com/osodevops/strimzi-backup-operator/commit/6b1c4e83b37ca8b27afb1dc46ca20287d0d85f89)

---
*Auto-generated by [Helm Chart Sync Workflow](https://github.com/osodevops/strimzi-backup-operator/actions/runs/25987417206)*