### PR TITLE
chore(kafka-backup-operator): sync chart v1.0.8

### DIFF
--- a/charts/kafka-backup-operator/Chart.yaml
+++ b/charts/kafka-backup-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kafka-backup-operator
 description: A Kubernetes operator for managing Kafka backup and restore operations
 type: application
-version: 1.0.7
-appVersion: "1.0.7"
+version: 1.0.8
+appVersion: "1.0.8"
 home: https://github.com/osodevops/kafka-backup-operator
 sources:
   - https://github.com/osodevops/kafka-backup-operator


### PR DESCRIPTION
## Summary

Automated sync of `kafka-backup-operator` Helm chart.

**Chart Version:** `1.0.8`
**App Version:** `1.0.8`
**Source Commit:** [`3b0198c4722bfbc50a925315906194cc889ab6f0`](https://github.com/osodevops/kafka-backup-operator/commit/3b0198c4722bfbc50a925315906194cc889ab6f0)
**Source Release:** [v1.0.8](https://github.com/osodevops/kafka-backup-operator/releases/tag/v1.0.8)

Image `ghcr.io/osodevops/kafka-backup-operator:1.0.8` was published by the upstream release workflow before this PR was opened.

---
*Auto-generated by [Release Workflow](https://github.com/osodevops/kafka-backup-operator/actions/runs/26123272697)*