### PR TITLE
chore(strimzi-backup-operator): sync chart v0.2.6

### DIFF
--- a/charts/strimzi-backup-operator/Chart.yaml
+++ b/charts/strimzi-backup-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: strimzi-backup-operator
 description: Kubernetes operator for Kafka backup and restore, integrated with Strimzi
 type: application
-version: 0.2.5
-appVersion: "0.2.5"
+version: 0.2.6
+appVersion: "0.2.6"
 home: https://github.com/osodevops/strimzi-backup-operator
 sources:
   - https://github.com/osodevops/strimzi-backup-operator

--- a/charts/strimzi-backup-operator/crds/kafkabackups.yaml
+++ b/charts/strimzi-backup-operator/crds/kafkabackups.yaml
@@ -667,8 +667,6 @@ spec:
                         description: Container security context (pass-through to k8s SecurityContext)
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
-                    required:
-                    - securityContext
                     type: object
                   pod:
                     description: Pod-level overrides
@@ -678,6 +676,23 @@ spec:
                         description: Pod affinity rules (pass-through to k8s Affinity)
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
+                      hostAliases:
+                        description: Pod host aliases (pass-through to k8s HostAlias)
+                        items:
+                          description: HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
+                          properties:
+                            hostnames:
+                              description: Hostnames for the above IP address.
+                              items:
+                                type: string
+                              type: array
+                            ip:
+                              description: IP address of the host file entry.
+                              type: string
+                          required:
+                          - ip
+                          type: object
+                        type: array
                       imagePullSecrets:
                         description: Image pull secrets
                         items:
@@ -709,9 +724,6 @@ spec:
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
                         type: array
-                    required:
-                    - affinity
-                    - securityContext
                     type: object
                 type: object
               topics:

--- a/charts/strimzi-backup-operator/crds/kafkarestores.yaml
+++ b/charts/strimzi-backup-operator/crds/kafkarestores.yaml
@@ -465,8 +465,6 @@ spec:
                         description: Container security context (pass-through to k8s SecurityContext)
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
-                    required:
-                    - securityContext
                     type: object
                   pod:
                     description: Pod-level overrides
@@ -476,6 +474,23 @@ spec:
                         description: Pod affinity rules (pass-through to k8s Affinity)
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
+                      hostAliases:
+                        description: Pod host aliases (pass-through to k8s HostAlias)
+                        items:
+                          description: HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
+                          properties:
+                            hostnames:
+                              description: Hostnames for the above IP address.
+                              items:
+                                type: string
+                              type: array
+                            ip:
+                              description: IP address of the host file entry.
+                              type: string
+                          required:
+                          - ip
+                          type: object
+                        type: array
                       imagePullSecrets:
                         description: Image pull secrets
                         items:
@@ -507,9 +522,6 @@ spec:
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
                         type: array
-                    required:
-                    - affinity
-                    - securityContext
                     type: object
                 type: object
               topicMapping:


### PR DESCRIPTION
## Summary

Automated sync of `strimzi-backup-operator` Helm chart.

**Chart Version:** `0.2.6`
**App Version:** `0.2.6`
**Source Commit:** [`5364673d0e26f433109376c3dbc9be0b3d7e4960`](https://github.com/osodevops/strimzi-backup-operator/commit/5364673d0e26f433109376c3dbc9be0b3d7e4960)

---
*Auto-generated by [Helm Chart Sync Workflow](https://github.com/osodevops/strimzi-backup-operator/actions/runs/26874699357)*