### PR TITLE
chore(strimzi-backup-operator): sync chart v0.2.8

### DIFF
--- a/charts/strimzi-backup-operator/Chart.yaml
+++ b/charts/strimzi-backup-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: strimzi-backup-operator
 description: Kubernetes operator for Kafka backup and restore, integrated with Strimzi
 type: application
-version: 0.2.7
-appVersion: "0.2.7"
+version: 0.2.8
+appVersion: "0.2.8"
 home: https://github.com/osodevops/strimzi-backup-operator
 sources:
   - https://github.com/osodevops/strimzi-backup-operator

--- a/charts/strimzi-backup-operator/crds/kafkabackups.yaml
+++ b/charts/strimzi-backup-operator/crds/kafkabackups.yaml
@@ -718,6 +718,10 @@ spec:
                         description: Pod security context (pass-through to k8s PodSecurityContext)
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
+                      serviceAccountName:
+                        description: Service account for job pods. Must exist in the namespace of this resource. Overrides the operator-wide default (BACKUP_JOB_SERVICE_ACCOUNT).
+                        nullable: true
+                        type: string
                       tolerations:
                         description: Pod tolerations (pass-through to k8s Tolerations)
                         items:

--- a/charts/strimzi-backup-operator/crds/kafkarestores.yaml
+++ b/charts/strimzi-backup-operator/crds/kafkarestores.yaml
@@ -516,6 +516,10 @@ spec:
                         description: Pod security context (pass-through to k8s PodSecurityContext)
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
+                      serviceAccountName:
+                        description: Service account for job pods. Must exist in the namespace of this resource. Overrides the operator-wide default (BACKUP_JOB_SERVICE_ACCOUNT).
+                        nullable: true
+                        type: string
                       tolerations:
                         description: Pod tolerations (pass-through to k8s Tolerations)
                         items:
@@ -540,6 +544,21 @@ spec:
                   - targetTopic
                   type: object
                 type: array
+              topics:
+                description: Topics to restore, selected by include/exclude glob (or `~`-prefixed regex) patterns matched against source topic names in the backup. All topics are restored when omitted. Filtering is applied before topicMapping renames.
+                nullable: true
+                properties:
+                  exclude:
+                    description: Glob patterns for topics to exclude
+                    items:
+                      type: string
+                    type: array
+                  include:
+                    description: Glob patterns for topics to include
+                    items:
+                      type: string
+                    type: array
+                type: object
             required:
             - backupRef
             - strimziClusterRef

--- a/charts/strimzi-backup-operator/values.yaml
+++ b/charts/strimzi-backup-operator/values.yaml
@@ -25,8 +25,11 @@ serviceAccount:
   name: ""
 
 backupJobs:
-  # Service account used by backup and restore job pods.
+  # Default service account used by backup and restore job pods.
   # If empty, the chart passes the operator service account name.
+  # The account must exist in each namespace where KafkaBackup/KafkaRestore
+  # resources are created; individual resources can override it with
+  # spec.template.pod.serviceAccountName.
   serviceAccountName: ""
 
 # Azure Workload Identity configuration


### PR DESCRIPTION
## Summary

Automated sync of `strimzi-backup-operator` Helm chart.

**Chart Version:** `0.2.8`
**App Version:** `0.2.8`
**Source Commit:** [`e4d13e45515918b30fcd3abef4a529e6b905241e`](https://github.com/osodevops/strimzi-backup-operator/commit/e4d13e45515918b30fcd3abef4a529e6b905241e)

---
*Auto-generated by [Helm Chart Sync Workflow](https://github.com/osodevops/strimzi-backup-operator/actions/runs/27330256445)*