### PR TITLE
chore(strimzi-backup-operator): sync chart v0.2.10

### DIFF
--- a/charts/strimzi-backup-operator/Chart.yaml
+++ b/charts/strimzi-backup-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: strimzi-backup-operator
 description: Kubernetes operator for Kafka backup and restore, integrated with Strimzi
 type: application
-version: 0.2.8
-appVersion: "0.2.8"
+version: 0.2.10
+appVersion: "0.2.10"
 home: https://github.com/osodevops/strimzi-backup-operator
 sources:
   - https://github.com/osodevops/strimzi-backup-operator

--- a/charts/strimzi-backup-operator/crds/kafkabackups.yaml
+++ b/charts/strimzi-backup-operator/crds/kafkabackups.yaml
@@ -96,6 +96,12 @@ spec:
                 required:
                 - type
                 type: object
+              backoffLimit:
+                description: Number of pod retries before a backup Job is marked failed (`spec.backoffLimit` on generated Jobs, including scheduled CronJob runs). Defaults to 3.
+                format: int32
+                minimum: 0.0
+                nullable: true
+                type: integer
               backup:
                 description: Backup options (compression, encryption, parallelism)
                 nullable: true

--- a/charts/strimzi-backup-operator/crds/kafkarestores.yaml
+++ b/charts/strimzi-backup-operator/crds/kafkarestores.yaml
@@ -93,6 +93,12 @@ spec:
                 required:
                 - type
                 type: object
+              backoffLimit:
+                description: 'Number of pod retries before the restore Job is marked failed (`spec.backoffLimit` on the generated Job). Defaults to 0 so a restore runs exactly once: restores append to or purge target topics, so a retry of a partially completed attempt can duplicate data and must be opted into deliberately.'
+                format: int32
+                minimum: 0.0
+                nullable: true
+                type: integer
               backupRef:
                 description: Reference to the source backup
                 properties:


### PR DESCRIPTION
## Summary

Automated sync of `strimzi-backup-operator` Helm chart.

**Chart Version:** `0.2.10`
**App Version:** `0.2.10`
**Source Commit:** [`a55773055f687ccf50b930b09f971b80de9a2acf`](https://github.com/osodevops/strimzi-backup-operator/commit/a55773055f687ccf50b930b09f971b80de9a2acf)

---
*Auto-generated by [Helm Chart Sync Workflow](https://github.com/osodevops/strimzi-backup-operator/actions/runs/27400980816)*