### PR TITLE
chore(strimzi-backup-operator): sync chart v0.2.11

### DIFF
--- a/charts/strimzi-backup-operator/Chart.yaml
+++ b/charts/strimzi-backup-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: strimzi-backup-operator
 description: Kubernetes operator for Kafka backup and restore, integrated with Strimzi
 type: application
-version: 0.2.10
-appVersion: "0.2.10"
+version: 0.2.11
+appVersion: "0.2.11"
 home: https://github.com/osodevops/strimzi-backup-operator
 sources:
   - https://github.com/osodevops/strimzi-backup-operator


### PR DESCRIPTION
## Summary

Automated sync of `strimzi-backup-operator` Helm chart.

**Chart Version:** `0.2.11`
**App Version:** `0.2.11`
**Source Commit:** [`c38e98bd0c24f1925270a7d29cbc8a9d5daa0d68`](https://github.com/osodevops/strimzi-backup-operator/commit/c38e98bd0c24f1925270a7d29cbc8a9d5daa0d68)

---
*Auto-generated by [Helm Chart Sync Workflow](https://github.com/osodevops/strimzi-backup-operator/actions/runs/28666821380)*