### PR TITLE
chore(strimzi-backup-operator): sync chart v0.2.12

### DIFF
--- a/charts/strimzi-backup-operator/Chart.yaml
+++ b/charts/strimzi-backup-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: strimzi-backup-operator
 description: Kubernetes operator for Kafka backup and restore, integrated with Strimzi
 type: application
-version: 0.2.11
-appVersion: "0.2.11"
+version: 0.2.12
+appVersion: "0.2.12"
 home: https://github.com/osodevops/strimzi-backup-operator
 sources:
   - https://github.com/osodevops/strimzi-backup-operator

--- a/charts/strimzi-backup-operator/crds/kafkabackups.yaml
+++ b/charts/strimzi-backup-operator/crds/kafkabackups.yaml
@@ -645,6 +645,10 @@ spec:
                     - key
                     - name
                     type: object
+                  listener:
+                    description: Optional name of the Kafka listener to connect through. When unset, the operator picks a listener whose authentication type matches this resource's spec.authentication, preferring in-cluster and TLS-encrypted listeners. Set this to override the automatic selection.
+                    nullable: true
+                    type: string
                   name:
                     description: Name of the Kafka CR
                     type: string

--- a/charts/strimzi-backup-operator/crds/kafkarestores.yaml
+++ b/charts/strimzi-backup-operator/crds/kafkarestores.yaml
@@ -443,6 +443,10 @@ spec:
                     - key
                     - name
                     type: object
+                  listener:
+                    description: Optional name of the Kafka listener to connect through. When unset, the operator picks a listener whose authentication type matches this resource's spec.authentication, preferring in-cluster and TLS-encrypted listeners. Set this to override the automatic selection.
+                    nullable: true
+                    type: string
                   name:
                     description: Name of the Kafka CR
                     type: string


### PR DESCRIPTION
## Summary

Automated sync of `strimzi-backup-operator` Helm chart.

**Chart Version:** `0.2.12`
**App Version:** `0.2.12`
**Source Commit:** [`49280bd35ab65ce585d4726299fb71a214a3b20e`](https://github.com/osodevops/strimzi-backup-operator/commit/49280bd35ab65ce585d4726299fb71a214a3b20e)

---
*Auto-generated by [Helm Chart Sync Workflow](https://github.com/osodevops/strimzi-backup-operator/actions/runs/28926858424)*