### PR TITLE
chore(strimzi-backup-operator): sync chart v0.2.16

### DIFF
--- a/charts/strimzi-backup-operator/Chart.yaml
+++ b/charts/strimzi-backup-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: strimzi-backup-operator
 description: Kubernetes operator for Kafka backup and restore, integrated with Strimzi
 type: application
-version: 0.2.14
-appVersion: "0.2.14"
+version: 0.2.16
+appVersion: "0.2.16"
 home: https://github.com/osodevops/strimzi-backup-operator
 sources:
   - https://github.com/osodevops/strimzi-backup-operator

--- a/charts/strimzi-backup-operator/crds/kafkabackups.yaml
+++ b/charts/strimzi-backup-operator/crds/kafkabackups.yaml
@@ -259,7 +259,7 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
                 type: array
               image:
-                description: 'Container image for the backup job (default: osodevops/kafka-backup:v0.15.6)'
+                description: 'Container image for the backup job (default: osodevops/kafka-backup:v0.15.11)'
                 nullable: true
                 type: string
               logging:
@@ -313,8 +313,14 @@ spec:
                     description: Enable the kafka-backup metrics server
                     nullable: true
                     type: boolean
+                  keepAliveSeconds:
+                    description: Seconds to keep serving metrics after a one-shot operation completes
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
                   maxPartitionLabels:
-                    description: Maximum topic/partition labels emitted by the core metrics registry
+                    description: 'Maximum unique topic/partition series emitted by the core metrics registry; set to 0 for unlimited series (default: 100)'
                     format: uint
                     minimum: 0.0
                     nullable: true

--- a/charts/strimzi-backup-operator/crds/kafkarestores.yaml
+++ b/charts/strimzi-backup-operator/crds/kafkarestores.yaml
@@ -192,7 +192,7 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
                 type: array
               image:
-                description: 'Container image for the restore job (default: osodevops/kafka-backup:v0.15.6)'
+                description: 'Container image for the restore job (default: osodevops/kafka-backup:v0.15.11)'
                 nullable: true
                 type: string
               logging:
@@ -246,8 +246,14 @@ spec:
                     description: Enable the kafka-backup metrics server
                     nullable: true
                     type: boolean
+                  keepAliveSeconds:
+                    description: Seconds to keep serving metrics after a one-shot operation completes
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
                   maxPartitionLabels:
-                    description: Maximum topic/partition labels emitted by the core metrics registry
+                    description: 'Maximum unique topic/partition series emitted by the core metrics registry; set to 0 for unlimited series (default: 100)'
                     format: uint
                     minimum: 0.0
                     nullable: true

--- a/charts/strimzi-backup-operator/templates/NOTES.txt
+++ b/charts/strimzi-backup-operator/templates/NOTES.txt
@@ -48,3 +48,8 @@ Metrics are available at:
   kubectl port-forward svc/{{ include "strimzi-backup-operator.fullname" . }}-metrics {{ .Values.service.port }}:{{ .Values.service.port }}
   curl http://localhost:{{ .Values.service.port }}/metrics
 {{- end }}
+{{- if and .Values.metrics.enabled .Values.metrics.jobPodMonitor.enabled }}
+
+Backup and restore job metrics are discovered by PodMonitor
+{{ include "strimzi-backup-operator.fullname" . }}-jobs on the named `metrics` port.
+{{- end }}

--- a/charts/strimzi-backup-operator/templates/jobpodmonitor.yaml
+++ b/charts/strimzi-backup-operator/templates/jobpodmonitor.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.metrics.enabled .Values.metrics.jobPodMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "strimzi-backup-operator.fullname" . }}-jobs
+  {{- if .Values.metrics.jobPodMonitor.namespace }}
+  namespace: {{ .Values.metrics.jobPodMonitor.namespace }}
+  {{- end }}
+  labels:
+    {{- include "strimzi-backup-operator.labels" . | nindent 4 }}
+    {{- with .Values.metrics.jobPodMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  namespaceSelector:
+    {{- toYaml .Values.metrics.jobPodMonitor.namespaceSelector | nindent 4 }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/managed-by: kafka-backup-operator
+      kafkabackup.com/metrics: enabled
+  podMetricsEndpoints:
+    - port: metrics
+      interval: {{ .Values.metrics.jobPodMonitor.interval }}
+      scrapeTimeout: {{ .Values.metrics.jobPodMonitor.scrapeTimeout }}
+      path: {{ .Values.metrics.jobPodMonitor.path }}
+{{- end }}

--- a/charts/strimzi-backup-operator/values.yaml
+++ b/charts/strimzi-backup-operator/values.yaml
@@ -100,6 +100,17 @@ metrics:
     interval: 30s
     scrapeTimeout: 10s
     labels: {}
+  # Scrape kafka-backup job pods directly. This is separate from the
+  # ServiceMonitor above, which only scrapes the operator on port 9090.
+  jobPodMonitor:
+    enabled: false
+    namespace: ""
+    namespaceSelector:
+      any: true
+    interval: 30s
+    scrapeTimeout: 10s
+    path: /metrics
+    labels: {}
 
 # CRD installation
 crds:


### PR DESCRIPTION
## Summary

Automated sync of `strimzi-backup-operator` Helm chart.

**Chart Version:** `0.2.16`
**App Version:** `0.2.16`
**Source Commit:** [`a97c06b6714e0479b0dbbd5fb2903a4d41c7eed4`](https://github.com/osodevops/strimzi-backup-operator/commit/a97c06b6714e0479b0dbbd5fb2903a4d41c7eed4)

---
*Auto-generated by [Helm Chart Sync Workflow](https://github.com/osodevops/strimzi-backup-operator/actions/runs/29697449710)*