### PR TITLE
chore(kafka-backup-operator): sync chart v1.1.1

### DIFF
--- a/charts/kafka-backup-operator/Chart.yaml
+++ b/charts/kafka-backup-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kafka-backup-operator
 description: A Kubernetes operator for managing Kafka backup and restore operations
 type: application
-version: 1.1.0
-appVersion: "1.1.0"
+version: 1.1.1
+appVersion: "1.1.1"
 home: https://github.com/osodevops/kafka-backup-operator
 sources:
   - https://github.com/osodevops/kafka-backup-operator

--- a/charts/kafka-backup-operator/crds/all.yaml
+++ b/charts/kafka-backup-operator/crds/all.yaml
@@ -239,7 +239,7 @@ spec:
                     type: boolean
                   maxPartitionLabels:
                     default: 100
-                    description: 'Maximum partition labels to prevent cardinality explosion (default: 100)'
+                    description: 'Maximum unique topic/partition series emitted by core metrics; set to 0 for unlimited series (default: 100)'
                     format: uint
                     minimum: 0.0
                     type: integer


### PR DESCRIPTION
## Summary

Automated sync of `kafka-backup-operator` Helm chart.

**Chart Version:** `1.1.1`
**App Version:** `1.1.1`
**Source Commit:** [`04f04deaef54ee50c7ba07dd10f0b2d962f78825`](https://github.com/osodevops/kafka-backup-operator/commit/04f04deaef54ee50c7ba07dd10f0b2d962f78825)
**Source Release:** [v1.1.1](https://github.com/osodevops/kafka-backup-operator/releases/tag/v1.1.1)

Image `ghcr.io/osodevops/kafka-backup-operator:1.1.1` was published by the upstream release workflow before this PR was opened.

---
*Auto-generated by [Release Workflow](https://github.com/osodevops/kafka-backup-operator/actions/runs/29697472372)*