### PR TITLE
chore(strimzi-backup-operator): sync chart v0.2.18

### DIFF
--- a/charts/strimzi-backup-operator/Chart.yaml
+++ b/charts/strimzi-backup-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: strimzi-backup-operator
 description: Kubernetes operator for Kafka backup and restore, integrated with Strimzi
 type: application
-version: 0.2.17
-appVersion: "0.2.17"
+version: 0.2.18
+appVersion: "0.2.18"
 home: https://github.com/osodevops/strimzi-backup-operator
 sources:
   - https://github.com/osodevops/strimzi-backup-operator

--- a/charts/strimzi-backup-operator/crds/kafkabackups.yaml
+++ b/charts/strimzi-backup-operator/crds/kafkabackups.yaml
@@ -236,7 +236,7 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
                 type: array
               image:
-                description: 'Container image for the backup job (default: osodevops/kafka-backup:v0.15.11)'
+                description: 'Container image for the backup job (default: osodevops/kafka-backup:v0.15.12)'
                 nullable: true
                 type: string
               logging:

--- a/charts/strimzi-backup-operator/crds/kafkarestores.yaml
+++ b/charts/strimzi-backup-operator/crds/kafkarestores.yaml
@@ -192,7 +192,7 @@ spec:
                   x-kubernetes-preserve-unknown-fields: true
                 type: array
               image:
-                description: 'Container image for the restore job (default: osodevops/kafka-backup:v0.15.11)'
+                description: 'Container image for the restore job (default: osodevops/kafka-backup:v0.15.12)'
                 nullable: true
                 type: string
               logging:


### PR DESCRIPTION
## Summary

Automated sync of `strimzi-backup-operator` Helm chart.

**Chart Version:** `0.2.18`
**App Version:** `0.2.18`
**Source Commit:** [`fb687348bf1a1743a245e8fcb8fe50d0e9492c58`](https://github.com/osodevops/strimzi-backup-operator/commit/fb687348bf1a1743a245e8fcb8fe50d0e9492c58)

---
*Auto-generated by [Helm Chart Sync Workflow](https://github.com/osodevops/strimzi-backup-operator/actions/runs/29864289294)*